### PR TITLE
URL encode target header in PATCH requests

### DIFF
--- a/src/mcp_knowledge_base/obsidian.py
+++ b/src/mcp_knowledge_base/obsidian.py
@@ -1,4 +1,5 @@
 import requests
+import urllib.parse
 from typing import Any
 
 class Obsidian():
@@ -106,7 +107,7 @@ class Obsidian():
             'Content-Type': 'text/markdown',
             'Operation': operation,
             'Target-Type': target_type,
-            'Target': target
+            'Target': urllib.parse.quote(target)
         }
         
         def call_fn():


### PR DESCRIPTION
## Problem

When using PATCH requests with the Obsidian API to modify content at specific locations (e.g., headings with special characters), the unencoded target path in the header could cause issues. The API would fail to properly handle targets containing characters that need to be escaped in URLs.

For example, when trying to patch a heading with special characters, the following error would occur:

```
Caught Exception. Error: 'latin-1' codec can't encode characters in position 0-3: ordinal not in range(256)
```

## Solution

Added URL encoding using `urllib.parse.quote()` to properly escape the target header value before sending PATCH requests. This ensures that special characters in heading paths or other targets are correctly encoded.

## Related Issues

There is a separate known issue where the API does not properly handle errors when trying to patch non-existent targets. In such cases, a PatchFailed error occurs on the obsidian-local-rest-api side but is not propagated back to the client. This is being addressed in a separate PR: coddingtonbear/obsidian-local-rest-api#139
