### PR TITLE
Add timeout settings to HTTP requests

### DIFF
--- a/src/mcp_knowledge_base/obsidian.py
+++ b/src/mcp_knowledge_base/obsidian.py
@@ -16,6 +16,7 @@ class Obsidian():
         self.host = host
         self.port = port
         self.verify_ssl = verify_ssl
+        self.timeout = (5, 15)
 
     def get_base_url(self) -> str:
         return f'{self.protocol}://{self.host}:{self.port}'
@@ -41,7 +42,7 @@ class Obsidian():
         url = f"{self.get_base_url()}/vault/"
         
         def call_fn():
-            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl)
+            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             
             return response.json()['files']
@@ -53,7 +54,7 @@ class Obsidian():
         url = f"{self.get_base_url()}/vault/{dirpath}/"
         
         def call_fn():
-            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl)
+            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             
             return response.json()['files']
@@ -64,7 +65,7 @@ class Obsidian():
         url = f"{self.get_base_url()}/vault/{filepath}"
     
         def call_fn():
-            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl)
+            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             
             return response.text
@@ -79,7 +80,7 @@ class Obsidian():
         }
         
         def call_fn():
-            response = requests.post(url, headers=self._get_headers(), params=params, verify=self.verify_ssl)
+            response = requests.post(url, headers=self._get_headers(), params=params, verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             return response.json()
 
@@ -93,7 +94,8 @@ class Obsidian():
                 url, 
                 headers=self._get_headers() | {'Content-Type': 'text/markdown'}, 
                 data=content,
-                verify=self.verify_ssl
+                verify=self.verify_ssl,
+                timeout=self.timeout
             )
             response.raise_for_status()
             return None
@@ -111,7 +113,7 @@ class Obsidian():
         }
         
         def call_fn():
-            response = requests.patch(url, headers=headers, data=content, verify=self.verify_ssl)
+            response = requests.patch(url, headers=headers, data=content, verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             return None
 
@@ -125,7 +127,7 @@ class Obsidian():
         }
         
         def call_fn():
-            response = requests.post(url, headers=headers, json=query, verify=self.verify_ssl)
+            response = requests.post(url, headers=headers, json=query, verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             return response.json()
 

--- a/src/mcp_knowledge_base/obsidian.py
+++ b/src/mcp_knowledge_base/obsidian.py
@@ -16,7 +16,7 @@ class Obsidian():
         self.host = host
         self.port = port
         self.verify_ssl = verify_ssl
-        self.timeout = (5, 15)
+        self.timeout = (3, 6)
 
     def get_base_url(self) -> str:
         return f'{self.protocol}://{self.host}:{self.port}'


### PR DESCRIPTION
This PR adds timeout settings to all HTTP requests made to Obsidian Local REST API to prevent potential freezes when the API becomes unresponsive.

## Background

There is a known issue with Obsidian Local REST API where it sometimes does not return a response when encountering errors (see coddingtonbear/obsidian-local-rest-api#139). While there might be other cases where error handling is insufficient in the API, this PR focuses on preventing indefinite freezes by adding proper timeout handling.

## Changes

- Added timeout settings `(3, 6)` (connect timeout, read timeout) to all HTTP requests
- Connect timeout: 3 seconds is sufficient for local connections
- Read timeout: 6 seconds allows enough time for operations while ensuring errors occur before MCP clients disconnect
  - MCP Inspector disconnects after ~10 seconds
  - Claude Desktop App disconnects after ~8 seconds

The client now fails gracefully with timeout errors instead of hanging indefinitely, and errors occur before MCP clients would disconnect.

This PR resolves #3.
