### PR TITLE
added base url for docker or remote server

### DIFF
--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -1,6 +1,12 @@
+import os
+from dotenv import load_dotenv
 import requests
 import urllib.parse
 from typing import Any
+
+load_dotenv()
+
+base_url = os.getenv("BASE_URL", "")
 
 class Obsidian():
     def __init__(
@@ -19,7 +25,10 @@ class Obsidian():
         self.timeout = (3, 6)
 
     def get_base_url(self) -> str:
-        return f'{self.protocol}://{self.host}:{self.port}'
+        if base_url != "":
+            return base_url
+        else:
+            return f'{self.protocol}://{self.host}:{self.port}'
     
     def _get_headers(self) -> dict:
         headers = {


### PR DESCRIPTION
If I install this MCP by mcpo, and I install it by docker on my laptop, then the host would be something like host.docker.internal, rather 127.0.0.1.

Or if I have obsidian in a remote laptop, I would like to access it from a remote host, then I would need definitely a new host url other than localhost.