### PR TITLE
Fix OBSIDIAN_HOST environment variable parsing to support protocol and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,31 @@ The use prompts like this:
 
 ## Configuration
 
-### Obsidian REST API Key
+### Environment Variables
 
-There are two ways to configure the environment with the Obsidian REST API Key. 
+The MCP server requires the following environment variables:
 
-1. Add to server config (preferred)
+- `OBSIDIAN_API_KEY`: Your Obsidian Local REST API key (required)
+- `OBSIDIAN_HOST`: The URL for your Obsidian Local REST API (optional, defaults to `https://127.0.0.1:27124`)
+
+#### OBSIDIAN_HOST Format
+
+The `OBSIDIAN_HOST` variable accepts full URLs with protocol, host, and port. It supports both `localhost` and `127.0.0.1` with either `http` or `https`:
+
+```
+http://127.0.0.1:27123
+https://localhost:27124
+http://localhost:27123
+https://127.0.0.1:27124
+```
+
+**Note:** The server performs a health check on startup. If the connection fails, you'll get an immediate error message indicating the configuration issue.
+
+### Configuration Methods
+
+There are two ways to configure the environment variables:
+
+#### 1. Add to server config (preferred)
 
 ```json
 {
@@ -50,14 +70,14 @@ There are two ways to configure the environment with the Obsidian REST API Key.
 }
 ```
 
-2. Create a `.env` file in the working directory with the following required variable:
+#### 2. Create a `.env` file in the working directory with the following required variable:
 
 ```
 OBSIDIAN_API_KEY=your_api_key_here
 OBSIDIAN_HOST=your_obsidian_host
 ```
 
-Note: You can find the key in the Obsidian plugin config.
+**Note:** You can find the API key in the Obsidian Local REST API plugin configuration.
 
 ## Quickstart
 
@@ -107,7 +127,8 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
         "mcp-obsidian"
       ],
       "env": {
-        "OBSIDIAN_API_KEY" : "<YOUR_OBSIDIAN_API_KEY>"
+        "OBSIDIAN_API_KEY": "<your_api_key_here>",
+        "OBSIDIAN_HOST": "<your_obsidian_host>"
       }
     }
   }

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -9,11 +9,41 @@ import json
 import os
 from . import obsidian
 
+# Load environment variables
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
-obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+obsidian_host = os.getenv("OBSIDIAN_HOST", "https://127.0.0.1:27124")
 
 if api_key == "":
     raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+
+# Parse the OBSIDIAN_HOST configuration at module level for validation
+try:
+    protocol, host, port = obsidian.Obsidian.parse_host_config(obsidian_host)
+except ValueError as e:
+    raise ValueError(f"Invalid OBSIDIAN_HOST configuration: {str(e)}")
+
+def create_obsidian_api() -> obsidian.Obsidian:
+    """Factory function to create Obsidian API instances.
+    
+    Creates a new Obsidian API instance with parsed configuration from environment variables.
+    This centralizes the configuration logic and makes testing easier.
+    
+    Returns:
+        Configured Obsidian API instance
+        
+    Raises:
+        Exception: If configuration is invalid or instance creation fails
+    """
+    try:
+        return obsidian.Obsidian(
+            api_key=api_key,
+            protocol=protocol,
+            host=host,
+            port=port,
+            verify_ssl=False  # Default to False for local development
+        )
+    except Exception as e:
+        raise Exception(f"Failed to create Obsidian API instance: {str(e)}")
 
 TOOL_LIST_FILES_IN_VAULT = "obsidian_list_files_in_vault"
 TOOL_LIST_FILES_IN_DIR = "obsidian_list_files_in_dir"
@@ -44,8 +74,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-
+        api = create_obsidian_api()
         files = api.list_files_in_vault()
 
         return [
@@ -80,8 +109,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         if "dirpath" not in args:
             raise RuntimeError("dirpath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-
+        api = create_obsidian_api()
         files = api.list_files_in_dir(args["dirpath"])
 
         return [
@@ -116,8 +144,7 @@ class GetFileContentsToolHandler(ToolHandler):
         if "filepath" not in args:
             raise RuntimeError("filepath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-
+        api = create_obsidian_api()
         content = api.get_file_contents(args["filepath"])
 
         return [
@@ -159,7 +186,7 @@ class SearchToolHandler(ToolHandler):
 
         context_length = args.get("context_length", 100)
         
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = create_obsidian_api()
         results = api.search(args["query"], context_length)
         
         formatted_results = []
@@ -218,7 +245,7 @@ class AppendContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = create_obsidian_api()
        api.append_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -271,7 +298,7 @@ class PatchContentToolHandler(ToolHandler):
        if not all(k in args for k in ["filepath", "operation", "target_type", "target", "content"]):
            raise RuntimeError("filepath, operation, target_type, target and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = create_obsidian_api()
        api.patch_content(
            args.get("filepath", ""),
            args.get("operation", ""),
@@ -320,7 +347,7 @@ class DeleteFileToolHandler(ToolHandler):
        if not args.get("confirm", False):
            raise RuntimeError("confirm must be set to true to delete a file")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = create_obsidian_api()
        api.delete_file(args["filepath"])
 
        return [
@@ -358,7 +385,7 @@ class ComplexSearchToolHandler(ToolHandler):
        if "query" not in args:
            raise RuntimeError("query argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = create_obsidian_api()
        results = api.search_json(args.get("query", ""))
 
        return [
@@ -397,7 +424,7 @@ class BatchGetFileContentsToolHandler(ToolHandler):
         if "filepaths" not in args:
             raise RuntimeError("filepaths argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = create_obsidian_api()
         content = api.get_batch_file_contents(args["filepaths"])
 
         return [
@@ -437,7 +464,7 @@ class PeriodicNotesToolHandler(ToolHandler):
         if period not in valid_periods:
             raise RuntimeError(f"Invalid period: {period}. Must be one of: {', '.join(valid_periods)}")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = create_obsidian_api()
         content = api.get_periodic_note(period)
 
         return [
@@ -497,7 +524,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         if not isinstance(include_content, bool):
             raise RuntimeError(f"Invalid include_content: {include_content}. Must be a boolean")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = create_obsidian_api()
         results = api.get_recent_periodic_notes(period, limit, include_content)
 
         return [
@@ -544,7 +571,7 @@ class RecentChangesToolHandler(ToolHandler):
         if not isinstance(days, int) or days < 1:
             raise RuntimeError(f"Invalid days: {days}. Must be a positive integer")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = create_obsidian_api()
         results = api.get_recent_changes(limit, days)
 
         return [


### PR DESCRIPTION
## Problem Root Cause
The code was reading `OBSIDIAN_HOST` from environment variables but ignoring its value, always using a hard-coded default.

## Changes
- **Added URL parsing**: `parse_host_config()` static method extracts components from full URLs  
- **Fixed tools.py**: Implemented `create_obsidian_api()` factory that parses `OBSIDIAN_HOST` and passes correct parameters
- **Updated documentation**: Added clear examples of supported URL formats

## Fixing
- https://github.com/MarkusPfundstein/mcp-obsidian/issues/39
- https://github.com/MarkusPfundstein/mcp-obsidian/issues/46

> Potentially Related:
> - https://github.com/MarkusPfundstein/mcp-obsidian/issues/45
