### PR TITLE
Adding a parameter to optionally retrieve metadata for periodic notes, in addition to just the content.

### DIFF
--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -172,11 +172,14 @@ class Obsidian():
 
         return self._safe_call(call_fn)
     
-    def get_periodic_note(self, period: str) -> Any:
+    def get_periodic_note(self, period: str, type: str = "content") -> Any:
         """Get current periodic note for the specified period.
         
         Args:
             period: The period type (daily, weekly, monthly, quarterly, yearly)
+            type: Type of the data to get ('content' or 'metadata'). 
+                'content' returns just the content in Markdown format. 
+                'metadata' includes note metadata (including paths, tags, etc.) and the content.. 
             
         Returns:
             Content of the periodic note
@@ -184,7 +187,10 @@ class Obsidian():
         url = f"{self.get_base_url()}/periodic/{period}/"
         
         def call_fn():
-            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl, timeout=self.timeout)
+            headers = self._get_headers()
+            if type == "metadata":
+                headers['Accept'] = 'application/vnd.olrapi.note+json'
+            response = requests.get(url, headers=headers, verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             
             return response.text

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -422,6 +422,12 @@ class PeriodicNotesToolHandler(ToolHandler):
                         "type": "string",
                         "description": "The period type (daily, weekly, monthly, quarterly, yearly)",
                         "enum": ["daily", "weekly", "monthly", "quarterly", "yearly"]
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The type of data to get ('content' or 'metadata'). 'content' returns just the content in Markdown format. 'metadata' includes note metadata (including paths, tags, etc.) and the content.",
+                        "default": "content",
+                        "enum": ["content", "metadata"]
                     }
                 },
                 "required": ["period"]
@@ -436,9 +442,14 @@ class PeriodicNotesToolHandler(ToolHandler):
         valid_periods = ["daily", "weekly", "monthly", "quarterly", "yearly"]
         if period not in valid_periods:
             raise RuntimeError(f"Invalid period: {period}. Must be one of: {', '.join(valid_periods)}")
+        
+        type = args["type"] if "type" in args else "content"
+        valid_types = ["content", "metadata"]
+        if type not in valid_types:
+            raise RuntimeError(f"Invalid type: {type}. Must be one of: {', '.join(valid_types)}")
 
         api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-        content = api.get_periodic_note(period)
+        content = api.get_periodic_note(period,type)
 
         return [
             TextContent(


### PR DESCRIPTION
Sometimes, the agent needs to know the complete path for the periodic note, whether it's for creating a new one or updating the content. 

Having only the content can limit the tool and may lead the AI to search for or patch the wrong note. 

This is especially helpful when you have custom paths for your periodic notes. 

This update addresses that.