### PR TITLE
Fix: Resolve Chinese character encoding issues in MCP tools

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -51,7 +51,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(files, indent=2)
+                text=json.dumps(files, indent=2, ensure_ascii=False)
             )
         ]
     
@@ -87,7 +87,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(files, indent=2)
+                text=json.dumps(files, indent=2, ensure_ascii=False)
             )
         ]
     
@@ -123,7 +123,7 @@ class GetFileContentsToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(content, indent=2)
+                text=content
             )
         ]
     
@@ -185,7 +185,7 @@ class SearchToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(formatted_results, indent=2)
+                text=json.dumps(formatted_results, indent=2, ensure_ascii=False)
             )
         ]
     
@@ -430,7 +430,7 @@ class ComplexSearchToolHandler(ToolHandler):
        return [
            TextContent(
                type="text",
-               text=json.dumps(results, indent=2)
+               text=json.dumps(results, indent=2, ensure_ascii=False)
            )
        ]
 
@@ -580,7 +580,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(results, indent=2)
+                text=json.dumps(results, indent=2, ensure_ascii=False)
             )
         ]
         
@@ -627,6 +627,6 @@ class RecentChangesToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(results, indent=2)
+                text=json.dumps(results, indent=2, ensure_ascii=False)
             )
         ]


### PR DESCRIPTION
- Fix GetFileContentsToolHandler where file content was JSON-serialized causing encoding issues
- Add ensure_ascii=False parameter to all json.dumps() calls to prevent Chinese characters from being escaped as Unicode sequences
- Ensure Chinese file names and content display correctly without \u6570\u5b66 escape characters

Fixed tools include:
- obsidian_get_file_contents (primary fix)
- obsidian_list_files_in_vault
- obsidian_list_files_in_dir
- obsidian_simple_search
- obsidian_complex_search
- obsidian_get_recent_periodic_notes
- obsidian_get_recent_changes