### PR TITLE
Fix: tool `list_files_in_dir` throws error when the dirpath passed in endswith slash

### DIFF
--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -57,6 +57,8 @@ class Obsidian():
 
         
     def list_files_in_dir(self, dirpath: str) -> Any:
+        if dirpath.endswith("/"):
+            dirpath = dirpath[:-1]
         url = f"{self.get_base_url()}/vault/{dirpath}/"
         
         def call_fn():

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -2,6 +2,7 @@ import requests
 import urllib.parse
 import os
 from typing import Any
+from pathlib import Path
 
 class Obsidian():
     def __init__(
@@ -57,8 +58,7 @@ class Obsidian():
 
         
     def list_files_in_dir(self, dirpath: str) -> Any:
-        if dirpath.endswith("/"):
-            dirpath = dirpath[:-1]
+        dirpath = Path(dirpath).as_posix()
         url = f"{self.get_base_url()}/vault/{dirpath}/"
         
         def call_fn():


### PR DESCRIPTION
In the tool `list_files_in_dir` implementation, when the dirpath passed in is ends with slash, it will build the final obsidian path with the extra slash, which will cause error.