### PR TITLE
Fix: Ensure correct character encoding for tool outputs

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -51,7 +51,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(files, indent=2)
+                text=json.dumps(files, indent=2, ensure_ascii=False)
             )
         ]
     
@@ -87,7 +87,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(files, indent=2)
+                text=json.dumps(files, indent=2, ensure_ascii=False)
             )
         ]
     
@@ -123,7 +123,7 @@ class GetFileContentsToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(content, indent=2)
+                text=content
             )
         ]
     
@@ -185,7 +185,7 @@ class SearchToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(formatted_results, indent=2)
+                text=json.dumps(formatted_results, indent=2, ensure_ascii=False)
             )
         ]
     
@@ -430,7 +430,7 @@ class ComplexSearchToolHandler(ToolHandler):
        return [
            TextContent(
                type="text",
-               text=json.dumps(results, indent=2)
+               text=json.dumps(results, indent=2, ensure_ascii=False)
            )
        ]
 
@@ -580,7 +580,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(results, indent=2)
+                text=json.dumps(results, indent=2, ensure_ascii=False)
             )
         ]
         
@@ -627,6 +627,6 @@ class RecentChangesToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(results, indent=2)
+                text=json.dumps(results, indent=2, ensure_ascii=False)
             )
         ]


### PR DESCRIPTION
#73 
This PR addresses an issue where non-ASCII characters in tool outputs were being incorrectly encoded, resulting in garbled text (e.g., `\u4f60\u597d\u4e16\u754c`).

The following changes have been made:

1. __Updated `json.dumps` calls:__ In `src/mcp_obsidian/tools.py`, all instances of `json.dumps` have been updated to include the `ensure_ascii=False` parameter. This ensures that multibyte characters are rendered correctly in the output.
2. __Corrected `GetFileContentsToolHandler`:__ Removed an unnecessary `json.dumps` call that was wrapping the raw text output. The handler now returns the file content directly, as expected.

These changes ensure proper handling of international characters across all relevant tools, improving the usability and correctness of the integration.
