### PR TITLE
Fix Windows UTF-8 encoding issues in MCP STDIO communication

### DIFF
--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -4,7 +4,18 @@ from collections.abc import Sequence
 from functools import lru_cache
 from typing import Any
 import os
+import sys
 from dotenv import load_dotenv
+
+# UTF-8 Fix for Windows MCP STDIO communication
+# Based on official MCP SQLite server fix (PR #378)
+if sys.platform == "win32":
+    # Only set if not already configured via environment
+    if not os.environ.get('PYTHONIOENCODING'):
+        # Configure stdin, stdout, stderr to use UTF-8
+        sys.stdin.reconfigure(encoding='utf-8')
+        sys.stdout.reconfigure(encoding='utf-8') 
+        sys.stderr.reconfigure(encoding='utf-8')
 from mcp.server import Server
 from mcp.types import (
     Tool,


### PR DESCRIPTION
Resolves Unicode character corruption (e.g., řemeslník → Ĺ™emeslnĂ­k) when writing content through MCP on Windows systems.

Changes:
- Add Windows-specific UTF-8 encoding configuration for stdin/stdout/stderr
- Only applies on Windows when PYTHONIOENCODING is not already set
- Process-local changes only, no system-wide impact

Based on official MCP SQLite server fix (modelcontextprotocol/servers#378) 