### PR TITLE
CLI refactored to Typer (+ test suite, --version, config validation, + configurable timeouts and skip TLS verification)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an MCP (Model Context Protocol) server that provides integration between Claude and Obsidian through the Obsidian Local REST API community plugin. It allows Claude to interact with Obsidian vaults by reading, searching, creating, and modifying notes.
+
+## Key Dependencies and Setup
+
+- Python 3.11+ required
+- Main dependencies: `mcp`, `python-dotenv`, `requests`
+- Uses UV package manager for dependency management
+- Requires Obsidian Local REST API plugin installed and configured in Obsidian
+
+## Development Commands
+
+```bash
+# Install dependencies and sync lockfile
+uv sync
+
+# Run the MCP server locally for development
+uv --directory /path/to/mcp-obsidian run mcp-obsidian
+
+# Run with UV from project directory
+uv run mcp-obsidian
+
+# Check types with pyright (development dependency)
+uv run pyright
+
+# Run all tests
+uv run pytest
+
+# Run tests with coverage
+uv run pytest --cov=src/mcp_obsidian --cov-report=term-missing
+
+# Run specific test file
+uv run pytest tests/test_obsidian.py
+
+# Run tests in verbose mode
+uv run pytest -v
+
+# Debug with MCP Inspector
+npx @modelcontextprotocol/inspector uv --directory /path/to/mcp-obsidian run mcp-obsidian
+
+# Monitor server logs
+tail -n 20 -f ~/Library/Logs/Claude/mcp-server-mcp-obsidian.log
+```
+
+## Architecture and Code Structure
+
+### Entry Points
+- `src/mcp_obsidian/__init__.py`: Package entry point, defines `main()` function
+- `src/mcp_obsidian/server.py`: MCP server implementation, handles tool registration and execution
+
+### Core Components
+
+1. **Tool System** (`src/mcp_obsidian/tools.py`):
+   - Base `ToolHandler` class for all tool implementations
+   - Each tool is a separate handler class inheriting from `ToolHandler`
+   - Tools are registered in `server.py` via `add_tool_handler()`
+   - Current tools: ListFilesInVault, ListFilesInDir, GetFileContents, Search, PatchContent, AppendContent, PutContent, DeleteFile, ComplexSearch, BatchGetFileContents, PeriodicNotes, RecentPeriodicNotes, RecentChanges
+
+2. **Obsidian API Client** (`src/mcp_obsidian/obsidian.py`):
+   - `Obsidian` class wraps the REST API communication
+   - Handles authentication via Bearer token
+   - Configurable protocol (http/https), host, and port
+   - Methods correspond to REST API endpoints
+   - Error handling via `_safe_call()` wrapper
+
+3. **MCP Server** (`src/mcp_obsidian/server.py`):
+   - Uses MCP's `Server` class
+   - Implements `@app.list_tools()` and `@app.call_tool()` handlers
+   - Tool handlers stored in global `tool_handlers` dictionary
+   - Runs as stdio server for Claude Desktop integration
+
+### Environment Configuration
+
+Required environment variables:
+- `OBSIDIAN_API_KEY`: API key from Obsidian Local REST API plugin (required)
+- `OBSIDIAN_HOST`: Obsidian host (default: "127.0.0.1")
+- `OBSIDIAN_PORT`: Obsidian port (default: "27124")
+- `OBSIDIAN_PROTOCOL`: Protocol to use (default: "https")
+
+These can be set via `.env` file or in Claude Desktop's configuration.
+
+### Adding New Tools
+
+To add a new tool:
+1. Create a new class in `tools.py` inheriting from `ToolHandler`
+2. Implement `get_tool_description()` with MCP Tool schema
+3. Implement `run_tool()` to handle the tool execution
+4. Register the handler in `server.py` using `add_tool_handler()`
+
+### OpenAPI Integration
+
+The repository includes `openapi.yaml` which documents the Obsidian REST API endpoints. This can be referenced when implementing new tools or understanding the API structure.
+
+## Testing Strategy
+
+### Test Structure
+- Tests are located in the `tests/` directory
+- Test files follow the pattern `test_*.py`
+- Fixtures are defined in `tests/conftest.py`
+- Mocking is used to avoid requiring a real Obsidian instance
+
+### Running Tests
+Tests use pytest and should be run before any refactoring:
+- `uv run pytest` - Run all tests
+- `uv run pytest -v` - Verbose output
+- `uv run pytest --cov=src/mcp_obsidian` - With coverage
+
+### Test Coverage Areas
+1. **Unit Tests**: Individual components (Obsidian client, tool handlers)
+2. **Integration Tests**: Tool registration and execution flow
+3. **Configuration Tests**: Environment variable handling and validation
+
+### Before Refactoring
+Always ensure all tests pass before and after refactoring. The test suite acts as a safety net to catch regressions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to MCP Obsidian
+
+Thank you for your interest in contributing to the MCP Obsidian server! This guide will help you get started with development and ensure your contributions align with the project's standards.
+
+## Development Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/your-org/mcp-obsidian.git
+   cd mcp-obsidian
+   ```
+
+2. **Install dependencies**
+   ```bash
+   uv sync --all-groups
+   ```
+
+3. **Set up environment variables**
+   Create a `.env` file with your Obsidian API credentials:
+   ```
+   OBSIDIAN_API_KEY=your_api_key
+   OBSIDIAN_HOST=127.0.0.1
+   OBSIDIAN_PORT=27124
+   OBSIDIAN_PROTOCOL=https
+   ```
+
+## Running Tests
+
+We maintain a test suite to ensure code quality and prevent regressions. **Always run tests before submitting a PR.**
+
+### Important: Test Environment
+**Tests require a clean environment.** If you have a `.env` file for local development, you must remove or rename it before running tests. The test suite will fail with a clear error message if a `.env` file is detected.
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run with verbose output
+uv run pytest -v
+
+# Run specific test file
+uv run pytest tests/test_obsidian.py
+
+# Run with coverage report
+uv run pytest --cov=src/mcp_obsidian --cov-report=term-missing
+```
+
+### Test Structure
+- `tests/conftest.py` - Shared fixtures and test configuration
+- `tests/test_basic_integration.py` - Core functionality tests (run these as smoke tests)
+- `tests/test_obsidian.py` - Obsidian API client tests
+- `tests/test_server.py` - MCP server tests
+- `tests/test_tools.py` - Individual tool handler tests
+
+## Code Style
+
+1. **Type hints**: Use type hints for all function parameters and return values
+2. **Error handling**: Use the `_safe_call` pattern for API calls
+3. **Tool handlers**: Inherit from `ToolHandler` base class
+4. **Environment variables**: Currently read directly, but will be refactored to use centralized configuration
+
+## Adding New Tools
+
+To add a new tool:
+
+1. **Create the tool handler** in `src/mcp_obsidian/tools.py`:
+   ```python
+   class YourToolHandler(ToolHandler):
+       def __init__(self):
+           super().__init__("obsidian_your_tool")
+       
+       def get_tool_description(self):
+           return Tool(
+               name=self.name,
+               description="Tool description",
+               inputSchema={...}
+           )
+       
+       def run_tool(self, args: dict):
+           # Implementation
+   ```
+
+2. **Register the handler** in `src/mcp_obsidian/server.py`:
+   ```python
+   add_tool_handler(tools.YourToolHandler())
+   ```
+
+3. **Add tests** in `tests/test_tools.py`:
+   ```python
+   class TestYourToolHandler:
+       def test_tool_description(self):
+           # Test the tool metadata
+       
+       def test_run_tool(self):
+           # Test the tool execution
+   ```
+
+4. **Update documentation** if needed
+
+## Testing Guidelines
+
+- **Mock external dependencies**: Use `unittest.mock` to mock Obsidian API calls
+- **Test both success and failure cases**: Include tests for error handling
+- **Use fixtures**: Leverage pytest fixtures in `conftest.py` for common test data
+- **Isolate tests**: Each test should be independent and not rely on others
+
+## Debugging
+
+For debugging MCP server interactions:
+
+```bash
+# Use MCP Inspector
+npx @modelcontextprotocol/inspector uv --directory /path/to/mcp-obsidian run mcp-obsidian
+
+# Monitor server logs
+tail -n 20 -f ~/Library/Logs/Claude/mcp-server-mcp-obsidian.log
+```
+
+## Pull Request Process
+
+1. **Create a feature branch**: `git checkout -b feature/your-feature`
+2. **Write tests** for your changes
+3. **Run the test suite**: `uv run pytest`
+4. **Check types**: `uv run pyright` (if applicable)
+5. **Update documentation** if needed
+6. **Create a pull request** with a clear description
+
+### PR Checklist
+- [ ] Tests pass locally
+- [ ] New code has tests
+- [ ] Documentation updated (if needed)
+- [ ] No hardcoded credentials or sensitive data
+- [ ] Tool handlers follow existing patterns
+
+## Upcoming Refactoring
+
+We're planning to refactor the configuration system to use Pydantic Settings. If you're working on configuration-related code, please coordinate to avoid conflicts. See `TODO.md` for details.
+
+## Questions?
+
+If you have questions about contributing, please open an issue for discussion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ uv run pytest --cov=src/mcp_obsidian --cov-report=term-missing
 1. **Type hints**: Use type hints for all function parameters and return values
 2. **Error handling**: Use the `_safe_call` pattern for API calls
 3. **Tool handlers**: Inherit from `ToolHandler` base class
-4. **Environment variables**: Currently read directly, but will be refactored to use centralized configuration
+4. **Configuration**: Use the centralized configuration system (see [Configuration Migration Guide](docs/CONFIG_MIGRATION.md))
 
 ## Adding New Tools
 
@@ -66,8 +66,8 @@ To add a new tool:
 1. **Create the tool handler** in `src/mcp_obsidian/tools.py`:
    ```python
    class YourToolHandler(ToolHandler):
-       def __init__(self):
-           super().__init__("obsidian_your_tool")
+       def __init__(self, config: Optional['Settings'] = None):
+           super().__init__("obsidian_your_tool", config)
        
        def get_tool_description(self):
            return Tool(
@@ -77,13 +77,17 @@ To add a new tool:
            )
        
        def run_tool(self, args: dict):
+           # Get configured Obsidian client
+           api = self.get_obsidian_client()
            # Implementation
    ```
 
 2. **Register the handler** in `src/mcp_obsidian/server.py`:
    ```python
-   add_tool_handler(tools.YourToolHandler())
+   add_tool_handler(tools.YourToolHandler(config))
    ```
+   
+   **Note**: See the [Configuration Migration Guide](docs/CONFIG_MIGRATION.md) for detailed information about the configuration system.
 
 3. **Add tests** in `tests/test_tools.py`:
    ```python

--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ The following environment variables can be used to configure the MCP server:
 
 ### Configuration Methods
 
-There are two ways to configure these environment variables:
+Configuration can be provided through multiple methods (in order of precedence):
 
-1. **Add to server config (preferred)**
+1. **Command-line arguments** (when running directly)
+2. **Environment variables** (as shown above)
+3. **`.env` file** in the working directory
+4. **Default values**
+
+#### For Claude Desktop
+
+**Add to server config (preferred)**
 
 ```json
 {
@@ -66,7 +73,9 @@ There are two ways to configure these environment variables:
 ```
 Sometimes Claude has issues detecting the location of uv / uvx. You can use `which uvx` to find and paste the full path in above config in such cases.
 
-2. **Create a `.env` file** in the working directory:
+#### Alternative: Using `.env` file
+
+Create a `.env` file in the working directory:
 
 ```
 OBSIDIAN_API_KEY=your_api_key_here
@@ -75,6 +84,26 @@ OBSIDIAN_PORT=your_obsidian_port
 ```
 
 Note: You can find the API key in the Obsidian plugin settings
+
+### Command-line Interface
+
+The server includes a CLI for testing and configuration validation:
+
+```bash
+# Check configuration
+mcp-obsidian --config-check
+
+# Run with custom settings
+mcp-obsidian --api-key YOUR_KEY --host 192.168.1.100 --port 8080
+
+# Show help
+mcp-obsidian --help
+
+# Show version
+mcp-obsidian --version
+```
+
+CLI arguments take precedence over environment variables and `.env` files.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,25 @@ The use prompts like this:
 
 ## Configuration
 
-### Obsidian REST API Key
+### Environment Variables
 
-There are two ways to configure the environment with the Obsidian REST API Key. 
+The following environment variables can be used to configure the MCP server:
 
-1. Add to server config (preferred)
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OBSIDIAN_API_KEY` | Yes | - | API key from Obsidian Local REST API plugin |
+| `OBSIDIAN_HOST` | No | `127.0.0.1` | Obsidian REST API host |
+| `OBSIDIAN_PORT` | No | `27124` | Obsidian REST API port |
+| `OBSIDIAN_PROTOCOL` | No | `https` | Protocol (`http` or `https`) |
+| `OBSIDIAN_CONNECT_TIMEOUT` | No | `3` | Connection timeout in seconds (1-60) |
+| `OBSIDIAN_READ_TIMEOUT` | No | `6` | Read timeout in seconds (1-300) |
+| `OBSIDIAN_VERIFY_SSL` | No | `false` | Verify SSL certificates |
+
+### Configuration Methods
+
+There are two ways to configure these environment variables:
+
+1. **Add to server config (preferred)**
 
 ```json
 {
@@ -52,7 +66,7 @@ There are two ways to configure the environment with the Obsidian REST API Key.
 ```
 Sometimes Claude has issues detecting the location of uv / uvx. You can use `which uvx` to find and paste the full path in above config in such cases.
 
-2. Create a `.env` file in the working directory with the following required variables:
+2. **Create a `.env` file** in the working directory:
 
 ```
 OBSIDIAN_API_KEY=your_api_key_here
@@ -60,10 +74,7 @@ OBSIDIAN_HOST=your_obsidian_host
 OBSIDIAN_PORT=your_obsidian_port
 ```
 
-Note:
-- You can find the API key in the Obsidian plugin config
-- Default port is 27124 if not specified
-- Default host is 127.0.0.1 if not specified
+Note: You can find the API key in the Obsidian plugin settings
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing requirements, and contribution guidelines.
 
+**Important for developers**: The project now uses a centralized configuration system. If you're working on tools or have an open PR, please review the [Configuration Migration Guide](docs/CONFIG_MIGRATION.md) to understand the changes.
+
 ### Building
 
 To prepare the package for distribution:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 ## Development
 
+### Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing requirements, and contribution guidelines.
+
 ### Building
 
 To prepare the package for distribution:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,357 @@
+# Configuration System Architecture
+
+## Overview
+
+The mcp-obsidian project uses a centralized, type-safe configuration system built on `pydantic-settings`. This document explains the core concepts and benefits of this approach.
+
+## Core Concepts
+
+### 1. Single Source of Truth
+
+All configuration logic lives in one place: `src/mcp_obsidian/config.py`
+
+**What's in config.py:**
+```python
+# config.py - This module defines the configuration system
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    """Configuration model with all settings defined as fields."""
+    obsidian_api_key: str
+    obsidian_host: str = "127.0.0.1"
+    obsidian_port: int = 27124
+    # ... more configuration fields
+
+def get_settings() -> Settings:
+    """Factory function that creates a Settings instance."""
+    return Settings()  # Reads from env vars and .env file
+```
+
+**How to use it in other modules:**
+```python
+# server.py - Using the configuration
+from mcp_obsidian.config import Settings, get_settings
+
+# Get a configured instance
+config = get_settings()  # Returns a Settings object with all values loaded
+
+# Now you can access configuration values
+print(config.obsidian_host)  # "127.0.0.1"
+print(config.obsidian_port)  # 27124
+
+# Pass to components that need it
+handler = ToolHandler(config)  # config is a Settings instance
+```
+
+**Benefits:**
+- No more searching through code to find where settings are defined
+- Consistent defaults across the entire application
+- Easy to see all available configuration options at a glance
+
+### 2. Multiple Configuration Sources
+
+The system supports configuration from multiple sources, with clear precedence:
+
+```
+1. Environment variables (highest priority)
+2. .env file (for local development)
+3. Default values in code (fallback)
+```
+
+Example flow:
+```python
+# In .env file
+OBSIDIAN_PORT=8080
+
+# In environment
+export OBSIDIAN_PORT=9090
+
+# Result: port will be 9090 (environment wins)
+```
+
+### 3. Type Safety and Validation
+
+Every configuration value is typed and validated:
+
+```python
+class Settings(BaseSettings):
+    obsidian_port: int = Field(default=27124, ge=1, le=65535)
+    obsidian_protocol: str = Field(default="https")
+    
+    @field_validator("obsidian_protocol")
+    def validate_protocol(cls, v: str) -> str:
+        if v.lower() not in ("http", "https"):
+            return "https"  # Safe default
+        return v.lower()
+```
+
+**Benefits:**
+- Catch configuration errors at startup, not runtime
+- IDE autocomplete and type hints
+- Automatic conversion (e.g., string "8080" → integer 8080)
+- Custom validation rules (e.g., port must be 1-65535)
+
+### 4. Configuration Injection
+
+Configuration is explicitly passed to components that need it:
+
+```python
+# Configuration is injected, not globally accessed
+class ToolHandler:
+    def __init__(self, config: Settings):
+        self.config = config
+```
+
+**Benefits:**
+- Clear dependencies - you know what uses configuration
+- Easy to test with mock configurations
+- No hidden global state
+
+### 5. Testability
+
+Different configurations for different test scenarios:
+
+```python
+# Unit test with specific config
+def test_with_custom_port():
+    # Create Settings instance directly with test values
+    test_config = Settings(
+        obsidian_api_key="test-key",
+        obsidian_port=9999
+    )
+    handler = ToolHandler(config=test_config)
+    assert handler.config.obsidian_port == 9999
+
+# Integration test with environment
+def test_with_env():
+    with patch.dict(os.environ, {"OBSIDIAN_PORT": "7777"}):
+        config = get_settings()  # This reads from the patched environment
+        assert config.obsidian_port == 7777
+```
+
+## How Settings and get_settings() Work Together
+
+The `config.py` module provides two key exports:
+
+1. **Settings class** - The schema/model that defines what configuration fields exist
+2. **get_settings() function** - Factory function that creates Settings instances
+
+Here's the complete `config.py` structure:
+
+```python
+# config.py
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    """The configuration schema - defines all fields and their types."""
+    
+    # Required fields (no default value)
+    obsidian_api_key: str
+    
+    # Optional fields (with defaults)
+    obsidian_host: str = "127.0.0.1"
+    obsidian_port: int = 27124
+    
+    # Pydantic configuration
+    model_config = SettingsConfigDict(
+        env_file=".env",  # Load from .env file if present
+        case_sensitive=False
+    )
+
+def get_settings() -> Settings:
+    """Create a new Settings instance.
+    
+    This function:
+    1. Reads environment variables
+    2. Reads .env file (if present)
+    3. Applies defaults
+    4. Validates all values
+    5. Returns a Settings instance
+    """
+    return Settings()
+
+# Optional: Cached version for production
+_settings_cache = None
+
+def get_cached_settings() -> Settings:
+    """Return the same Settings instance on every call (singleton)."""
+    global _settings_cache
+    if _settings_cache is None:
+        _settings_cache = Settings()
+    return _settings_cache
+```
+
+Usage patterns in different parts of the application:
+
+```python
+# server.py - Application startup
+from mcp_obsidian.config import Settings, get_settings
+
+# Create configuration instance once at startup
+config: Settings = get_settings()
+
+# Pass to all components that need it
+tool_handler = ToolHandler(config)
+```
+
+```python
+# tools.py - Tool implementation
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp_obsidian.config import Settings
+
+class ToolHandler:
+    def __init__(self, config: 'Settings'):
+        # We receive a Settings instance, not create one
+        self.config = config
+    
+    def use_config(self):
+        # Access configuration values through the instance
+        api_url = f"{self.config.obsidian_host}:{self.config.obsidian_port}"
+```
+
+## Configuration Flow
+
+```mermaid
+graph TD
+    A[Environment Variables] --> D[Settings class]
+    B[.env File] --> D
+    C[Default Values] --> D
+    D --> E[get_settings function]
+    E --> F[Settings Instance]
+    F --> G[Injected into Components]
+    G --> H[ToolHandlers]
+    G --> I[Obsidian Client]
+    G --> J[Server]
+```
+
+## Practical Benefits
+
+### For Development
+
+- **Auto-completion**: Your IDE knows all available settings and their types
+- **Early error detection**: Invalid configuration fails at startup, not during execution
+- **Easy debugging**: Set breakpoints in one config file to debug all settings
+
+### For Testing
+
+- **Isolation**: Each test can have its own configuration
+- **No side effects**: Tests don't affect each other's configuration
+- **Mock-friendly**: Easy to inject test configurations
+
+### For Deployment
+
+- **Environment-based**: Different settings for dev/staging/production
+- **Secure**: Sensitive values (API keys) stay in environment variables
+- **Validated**: Configuration errors caught before the application starts serving requests
+
+## Example: Adding a New Configuration Option
+
+Let's say you want to add a request retry count:
+
+1. **Define in `config.py`:**
+```python
+class Settings(BaseSettings):
+    # ... existing fields ...
+    
+    obsidian_max_retries: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        description="Maximum number of API request retries",
+        alias="OBSIDIAN_MAX_RETRIES"
+    )
+```
+
+2. **Use in your code:**
+```python
+class YourToolHandler(ToolHandler):
+    def make_request(self):
+        for attempt in range(self.config.obsidian_max_retries):
+            try:
+                return self.api.call()
+            except Exception:
+                if attempt == self.config.obsidian_max_retries - 1:
+                    raise
+```
+
+3. **Override in tests:**
+```python
+def test_no_retries():
+    config = Settings(
+        obsidian_api_key="test",
+        obsidian_max_retries=0  # No retries for this test
+    )
+    handler = YourToolHandler(config=config)
+    # Test behavior with no retries
+```
+
+4. **Configure in production:**
+```bash
+export OBSIDIAN_MAX_RETRIES=5
+```
+
+## Comparison with Previous Approach
+
+### Before (Scattered)
+```python
+# In tools.py
+api_key = os.getenv("OBSIDIAN_API_KEY", "")
+
+# In server.py
+host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+
+# In obsidian.py
+port = int(os.getenv("OBSIDIAN_PORT", "27124"))  # Hope it's a valid int!
+```
+
+Problems:
+- Configuration scattered across files
+- No type checking
+- No validation
+- Hard to test
+- Easy to miss settings
+
+### After (Centralized)
+```python
+# config.py - All configuration in one place
+class Settings(BaseSettings):
+    obsidian_api_key: str
+    obsidian_host: str = "127.0.0.1"
+    obsidian_port: int = 27124  # Automatically converted and validated
+
+def get_settings() -> Settings:
+    return Settings()
+
+# server.py - Using the configuration
+from mcp_obsidian.config import get_settings
+config = get_settings()
+```
+
+Benefits:
+- One place to look
+- Type-safe
+- Validated
+- Testable
+- Self-documenting
+
+## When to Use Configuration
+
+Use the configuration system for:
+- API endpoints and credentials
+- Timeouts and retry counts
+- Feature flags
+- Resource limits
+- Any value that might change between environments
+
+Don't use it for:
+- Constants that never change
+- Business logic rules
+- Computed values (use properties instead)
+
+## Further Reading
+
+- [Pydantic Settings Documentation](https://docs.pydantic.dev/latest/usage/pydantic_settings/)
+- [Configuration Migration Guide](CONFIG_MIGRATION.md) - How to migrate existing code
+- [12-Factor App Configuration](https://12factor.net/config) - Industry best practices

--- a/docs/CONFIG_MIGRATION.md
+++ b/docs/CONFIG_MIGRATION.md
@@ -1,0 +1,262 @@
+# Configuration System Migration Guide
+
+This guide helps developers understand the new centralized configuration system and how to migrate existing code.
+
+## Overview
+
+As of v0.3.0, mcp-obsidian uses a centralized configuration system based on `pydantic-settings`. This replaces the previous approach of reading environment variables directly in multiple places throughout the codebase.
+
+**New to the configuration system?** Read [CONFIG.md](CONFIG.md) first to understand the architecture and benefits.
+
+## Key Changes
+
+### Before (Scattered Configuration)
+```python
+# In tools.py
+api_key = os.getenv("OBSIDIAN_API_KEY", "")
+obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+
+# In each tool handler
+api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+```
+
+### After (Centralized Configuration)
+```python
+# Configuration loaded once
+from .config import Settings
+
+# Passed to components that need it
+class ToolHandler:
+    def __init__(self, tool_name: str, config: Settings = None):
+        self.config = config
+    
+    def get_obsidian_client(self):
+        return obsidian.Obsidian(config=self.config)
+```
+
+## For Tool Developers
+
+### Creating a New Tool
+
+When creating a new tool handler, follow this pattern:
+
+```python
+from typing import Optional
+from mcp.types import Tool, TextContent
+from .config import Settings
+
+class YourNewToolHandler(ToolHandler):
+    def __init__(self, config: Optional['Settings'] = None):
+        super().__init__("your_tool_name", config)
+    
+    def get_tool_description(self) -> Tool:
+        return Tool(
+            name=self.name,
+            description="Your tool description",
+            inputSchema={...}
+        )
+    
+    def run_tool(self, args: dict):
+        # Use the configured Obsidian client
+        api = self.get_obsidian_client()
+        
+        # Your tool logic here
+        result = api.some_method()
+        
+        return [TextContent(type="text", text=result)]
+```
+
+Then register it in `server.py`:
+
+```python
+# In server.py
+add_tool_handler(tools.YourNewToolHandler(config))
+```
+
+### Migrating Existing Tools
+
+If you have an existing tool that directly uses environment variables:
+
+1. **Update the `__init__` method** to accept config:
+   ```python
+   # Before
+   def __init__(self):
+       super().__init__("tool_name")
+   
+   # After
+   def __init__(self, config: Optional['Settings'] = None):
+       super().__init__("tool_name", config)
+   ```
+
+2. **Replace Obsidian instantiation**:
+   ```python
+   # Before
+   api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+   
+   # After
+   api = self.get_obsidian_client()
+   ```
+
+3. **Update registration** in server.py:
+   ```python
+   # Before
+   add_tool_handler(tools.YourToolHandler())
+   
+   # After
+   add_tool_handler(tools.YourToolHandler(config))
+   ```
+
+## For Core Contributors
+
+### Adding New Configuration Options
+
+To add a new configuration option:
+
+1. **Add to `config.py`**:
+   ```python
+   class Settings(BaseSettings):
+       # Existing fields...
+       
+       your_new_option: str = Field(
+           default="default_value",
+           description="Description of the option",
+           alias="YOUR_ENV_VAR_NAME"
+       )
+   ```
+
+2. **Add validation if needed**:
+   ```python
+   @field_validator("your_new_option")
+   @classmethod
+   def validate_option(cls, v: str) -> str:
+       # Your validation logic
+       return v
+   ```
+
+3. **Use in your code**:
+   ```python
+   # Access via config object
+   value = self.config.your_new_option
+   ```
+
+### Working with the Obsidian Client
+
+The `Obsidian` class supports both configuration styles:
+
+```python
+# New way (preferred) - with config object
+from .config import get_settings
+
+config = get_settings()
+client = Obsidian(config=config)
+
+# Old way (backward compatible) - with individual parameters
+client = Obsidian(
+    api_key="key",
+    host="127.0.0.1",
+    port=27124
+)
+
+# Config object takes precedence if both are provided
+client = Obsidian(
+    api_key="ignored",  # This will be ignored
+    config=config       # Config values will be used
+)
+```
+
+## Environment Variables
+
+The following environment variables are supported:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OBSIDIAN_API_KEY` | Yes | - | API key from Obsidian Local REST API plugin |
+| `OBSIDIAN_HOST` | No | `127.0.0.1` | Obsidian REST API host |
+| `OBSIDIAN_PORT` | No | `27124` | Obsidian REST API port |
+| `OBSIDIAN_PROTOCOL` | No | `https` | Protocol (`http` or `https`) |
+
+## Testing with Configuration
+
+### Unit Tests
+
+For unit tests, you can create a test configuration:
+
+```python
+from mcp_obsidian.config import Settings
+
+def test_your_tool():
+    # Create test config
+    test_config = Settings(
+        obsidian_api_key="test-key",
+        obsidian_host="test-host",
+        obsidian_port=8080
+    )
+    
+    # Create handler with test config
+    handler = YourToolHandler(config=test_config)
+    
+    # Mock the Obsidian client
+    with patch.object(handler, 'get_obsidian_client') as mock_client:
+        mock_client.return_value = MagicMock()
+        # Your test logic
+```
+
+### Integration Tests
+
+For integration tests, use environment variables:
+
+```python
+def test_with_env_vars():
+    with patch.dict(os.environ, {
+        "OBSIDIAN_API_KEY": "test-key",
+        "OBSIDIAN_HOST": "localhost",
+        "OBSIDIAN_PORT": "8080"
+    }):
+        config = get_settings()
+        handler = YourToolHandler(config=config)
+        # Your test logic
+```
+
+## Backward Compatibility
+
+The system maintains backward compatibility:
+
+1. **Obsidian client** still accepts individual parameters
+2. **Tool handlers** have optional config parameter
+3. **Environment variables** are still read as fallback
+
+However, new code should use the centralized configuration approach for consistency.
+
+## Common Issues and Solutions
+
+### Issue: "OBSIDIAN_API_KEY environment variable required"
+**Solution**: The error now comes from the config system. Ensure the environment variable is set or pass a config object with the API key.
+
+### Issue: Tool doesn't use new configuration
+**Solution**: Ensure the tool handler:
+1. Accepts `config` in `__init__`
+2. Passes it to `super().__init__()`
+3. Uses `self.get_obsidian_client()` instead of creating Obsidian instances directly
+
+### Issue: Tests failing after migration
+**Solution**: Mock or set environment variables in tests:
+```python
+# At the top of test file
+os.environ["OBSIDIAN_API_KEY"] = "test-api-key"
+```
+
+## Benefits of the New System
+
+1. **Single source of truth** - All configuration in one place
+2. **Type safety** - Pydantic validates types and values
+3. **Better testing** - Easy to inject test configurations
+4. **Future-proof** - Ready for CLI arguments via Typer
+5. **Clear defaults** - All defaults defined in one place
+6. **Validation** - Port ranges, protocol values, etc. are validated
+
+## Questions or Issues?
+
+If you encounter issues with the configuration system, please:
+1. Check this guide first
+2. Look at existing tool implementations for examples
+3. Open an issue with the `configuration` label

--- a/docs/CONFIG_MIGRATION.md
+++ b/docs/CONFIG_MIGRATION.md
@@ -6,6 +6,12 @@ This guide helps developers understand the new centralized configuration system 
 
 As of v0.3.0, mcp-obsidian uses a centralized configuration system based on `pydantic-settings`. This replaces the previous approach of reading environment variables directly in multiple places throughout the codebase.
 
+**Recent Changes (CLI Refactoring):**
+- Added Typer-based CLI with `--config-check`, `--version`, and configuration options
+- Fixed deferred initialization to support CLI functionality
+- Removed `python-dotenv` dependency (pydantic-settings handles .env files)
+- Changed from Field `alias` to `env_prefix` for cleaner environment variable handling
+
 **New to the configuration system?** Read [CONFIG.md](CONFIG.md) first to understand the architecture and benefits.
 
 ## Key Changes
@@ -70,7 +76,14 @@ Then register it in `server.py`:
 
 ```python
 # In server.py
-add_tool_handler(tools.YourNewToolHandler(config))
+# Add your handler class to the list
+handler_classes = [
+    tools.ListFilesInDirToolHandler,
+    tools.YourNewToolHandler,  # Add your new handler here
+    # ... other handlers
+]
+
+# Handlers are initialized automatically in initialize_tool_handlers()
 ```
 
 ### Migrating Existing Tools
@@ -99,11 +112,14 @@ If you have an existing tool that directly uses environment variables:
 
 3. **Update registration** in server.py:
    ```python
-   # Before
-   add_tool_handler(tools.YourToolHandler())
+   # Before (at module level)
+   tool_handlers["your_tool"] = tools.YourToolHandler()
    
-   # After
-   add_tool_handler(tools.YourToolHandler(config))
+   # After (add to handler_classes list)
+   handler_classes = [
+       # ... existing handlers
+       tools.YourToolHandler,
+   ]
    ```
 
 ## For Core Contributors
@@ -117,11 +133,11 @@ To add a new configuration option:
    class Settings(BaseSettings):
        # Existing fields...
        
-       your_new_option: str = Field(
+       obsidian_your_new_option: str = Field(
            default="default_value",
-           description="Description of the option",
-           alias="YOUR_ENV_VAR_NAME"
+           description="Description of the option"
        )
+       # Note: Environment variable will be OBSIDIAN_YOUR_NEW_OPTION (uppercase)
    ```
 
 2. **Add validation if needed**:
@@ -248,14 +264,58 @@ However, new code should use the centralized configuration approach for consiste
 os.environ["OBSIDIAN_API_KEY"] = "test-api-key"
 ```
 
+## CLI Interface
+
+The new CLI provides several useful commands:
+
+```bash
+# Check current configuration
+mcp-obsidian --config-check
+
+# Run with custom settings (overrides env vars)
+mcp-obsidian --api-key YOUR_KEY --host 192.168.1.100 --port 8080
+
+# Show version
+mcp-obsidian --version
+
+# Get help
+mcp-obsidian --help
+```
+
+### Adding CLI Options for New Configuration
+
+If your configuration option should be available via CLI:
+
+```python
+# In cli.py, add to the main() function parameters:
+new_option: Annotated[
+    Optional[str],
+    typer.Option(
+        "--new-option",
+        envvar="OBSIDIAN_NEW_OPTION",
+        help="Description of the option",
+        show_default="default_value",
+    ),
+] = None,
+
+# Then add to settings_kwargs dict comprehension:
+settings_kwargs = {
+    key: val for key, val in [
+        # ... existing options
+        ("obsidian_new_option", new_option),
+    ] if val is not None
+}
+```
+
 ## Benefits of the New System
 
 1. **Single source of truth** - All configuration in one place
 2. **Type safety** - Pydantic validates types and values
 3. **Better testing** - Easy to inject test configurations
-4. **Future-proof** - Ready for CLI arguments via Typer
+4. **CLI support** - Configuration via command-line arguments
 5. **Clear defaults** - All defaults defined in one place
 6. **Validation** - Port ranges, protocol values, etc. are validated
+7. **Proper precedence** - CLI args > env vars > .env file > defaults
 
 ## Questions or Issues?
 

--- a/docs/CONFIG_MIGRATION.md
+++ b/docs/CONFIG_MIGRATION.md
@@ -174,6 +174,9 @@ The following environment variables are supported:
 | `OBSIDIAN_HOST` | No | `127.0.0.1` | Obsidian REST API host |
 | `OBSIDIAN_PORT` | No | `27124` | Obsidian REST API port |
 | `OBSIDIAN_PROTOCOL` | No | `https` | Protocol (`http` or `https`) |
+| `OBSIDIAN_CONNECT_TIMEOUT` | No | `3` | Connection timeout in seconds (1-60) |
+| `OBSIDIAN_READ_TIMEOUT` | No | `6` | Read timeout in seconds (1-300) |
+| `OBSIDIAN_VERIFY_SSL` | No | `false` | Verify SSL certificates |
 
 ## Testing with Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pyright>=1.1.389",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=4.1.0",
+    "pytest-mock>=3.12.0",
+    "responses>=0.24.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.11"
 dependencies = [
  "mcp>=1.1.0",
  "pydantic-settings>=2.0.0",
- "python-dotenv>=1.0.1",
  "requests>=2.32.3",
+ "typer>=0.9.0",
 ]
 [[project.authors]]
 name = "Markus Pfundstein"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
  "mcp>=1.1.0",
+ "pydantic-settings>=2.0.0",
  "python-dotenv>=1.0.1",
  "requests>=2.32.3",
 ]

--- a/src/mcp_obsidian/__init__.py
+++ b/src/mcp_obsidian/__init__.py
@@ -1,9 +1,18 @@
 from . import server
 import asyncio
 
+__version__ = "0.2.1"
+
 def main():
     """Main entry point for the package."""
+    # Use CLI as the main entry point
+    import typer
+    from .cli import main as cli_main
+    typer.run(cli_main)
+
+def main_legacy():
+    """Legacy entry point that directly runs the server."""
     asyncio.run(server.main())
 
 # Optionally expose other important items at package level
-__all__ = ['main', 'server']
+__all__ = ['main', 'main_legacy', 'server', '__version__']

--- a/src/mcp_obsidian/cli.py
+++ b/src/mcp_obsidian/cli.py
@@ -1,0 +1,192 @@
+"""Command-line interface for mcp-obsidian using Typer."""
+import asyncio
+import sys
+from typing import Optional
+import typer
+from typing_extensions import Annotated
+
+from .config import Settings
+from . import server
+from . import __version__
+
+
+def version_callback(value: bool):
+    """Print version and exit."""
+    if value:
+        typer.echo(f"mcp-obsidian version: {__version__}")
+        raise typer.Exit()
+
+
+def main(
+    # Connection settings
+    api_key: Annotated[
+        Optional[str],
+        typer.Option(
+            "--api-key",
+            envvar="OBSIDIAN_API_KEY",
+            help="Obsidian REST API key (required)",
+            show_default=False,
+        ),
+    ] = None,
+    host: Annotated[
+        Optional[str],
+        typer.Option(
+            "--host",
+            envvar="OBSIDIAN_HOST",
+            help="Obsidian host",
+            show_default="127.0.0.1",
+        ),
+    ] = None,
+    port: Annotated[
+        Optional[int],
+        typer.Option(
+            "--port",
+            envvar="OBSIDIAN_PORT",
+            help="Obsidian port",
+            show_default="27124",
+        ),
+    ] = None,
+    protocol: Annotated[
+        Optional[str],
+        typer.Option(
+            "--protocol",
+            envvar="OBSIDIAN_PROTOCOL",
+            help="Protocol (http or https)",
+            show_default="https",
+        ),
+    ] = None,
+    # Timeout settings
+    connect_timeout: Annotated[
+        Optional[int],
+        typer.Option(
+            "--connect-timeout",
+            envvar="OBSIDIAN_CONNECT_TIMEOUT",
+            help="Connection timeout in seconds",
+            min=1,
+            max=60,
+            show_default="3",
+        ),
+    ] = None,
+    read_timeout: Annotated[
+        Optional[int],
+        typer.Option(
+            "--read-timeout",
+            envvar="OBSIDIAN_READ_TIMEOUT",
+            help="Read timeout in seconds",
+            min=1,
+            max=300,
+            show_default="6",
+        ),
+    ] = None,
+    # SSL settings
+    verify_ssl: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--verify-ssl/--no-verify-ssl",
+            envvar="OBSIDIAN_VERIFY_SSL",
+            help="Verify SSL certificates",
+            show_default="false",
+        ),
+    ] = None,
+    # Debugging
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Enable verbose logging",
+        ),
+    ] = False,
+    # Version
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--version",
+            callback=version_callback,
+            is_eager=True,
+            help="Show version and exit",
+        ),
+    ] = None,
+    # Config check
+    config_check: Annotated[
+        bool,
+        typer.Option(
+            "--config-check",
+            help="Check and display the current configuration, then exit",
+        ),
+    ] = False,
+):
+    """MCP server for Obsidian integration via Local REST API.
+    
+    The server communicates via stdio with the MCP client (e.g., Claude Desktop).
+    Configuration can be provided via environment variables, .env file, or CLI arguments.
+    CLI arguments take precedence over environment variables.
+    """
+    import logging
+    
+    # Configure logging
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        logging.debug("Verbose logging enabled")
+    else:
+        logging.basicConfig(level=logging.INFO)
+    
+    try:
+        # Build kwargs dict with only non-None values using dict comprehension
+        # Typer has already handled CLI args > env vars for its parameters
+        settings_kwargs = {
+            key: val for key, val in [
+                ("obsidian_api_key", api_key),
+                ("obsidian_host", host),
+                ("obsidian_port", port),
+                ("obsidian_protocol", protocol),
+                ("obsidian_connect_timeout", connect_timeout),
+                ("obsidian_read_timeout", read_timeout),
+                ("obsidian_verify_ssl", verify_ssl),
+            ] if val is not None
+        }
+        
+        # Create Settings instance
+        # Thanks to settings_customise_sources, values passed to __init__ (CLI args)
+        # take precedence over env vars and .env file
+        config = Settings(**settings_kwargs)
+        
+        if verbose:
+            logging.debug(f"Settings created with CLI overrides: {settings_kwargs}")
+        
+        # If config-check requested, display config and exit
+        if config_check:
+            typer.echo("Current configuration:")
+            typer.echo(f"  API Key: {'***' + config.obsidian_api_key[-4:] if len(config.obsidian_api_key) > 4 else '***'}")
+            typer.echo(f"  Host: {config.obsidian_host}")
+            typer.echo(f"  Port: {config.obsidian_port}")
+            typer.echo(f"  Protocol: {config.obsidian_protocol}")
+            typer.echo(f"  Base URL: {config.base_url}")
+            typer.echo(f"  Connect Timeout: {config.obsidian_connect_timeout}s")
+            typer.echo(f"  Read Timeout: {config.obsidian_read_timeout}s")
+            typer.echo(f"  Verify SSL: {config.obsidian_verify_ssl}")
+            typer.echo("\n✓ Configuration is valid")
+            return  # Just return instead of raising Exit
+        
+        # Replace the global config in server module
+        server.config = config
+        
+        if verbose:
+            logging.debug(f"Configuration loaded: host={config.obsidian_host}, port={config.obsidian_port}")
+        
+        # Run the server
+        asyncio.run(server.main())
+        
+    except ValueError as e:
+        typer.echo(f"Configuration error: {e}", err=True)
+        raise typer.Exit(code=1)
+    except Exception as e:
+        typer.echo(f"Server error: {e}", err=True)
+        if verbose:
+            import traceback
+            traceback.print_exc()
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/src/mcp_obsidian/config.py
+++ b/src/mcp_obsidian/config.py
@@ -1,0 +1,93 @@
+"""Centralized configuration management using Pydantic Settings."""
+from typing import Optional
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration settings for MCP Obsidian server.
+    
+    Settings are loaded from environment variables or .env file.
+    All settings can be overridden via environment variables.
+    """
+    
+    # Required settings
+    obsidian_api_key: str = Field(
+        ...,
+        description="API key for Obsidian Local REST API",
+        alias="OBSIDIAN_API_KEY"
+    )
+    
+    # Optional settings with defaults
+    obsidian_host: str = Field(
+        default="127.0.0.1",
+        description="Obsidian REST API host",
+        alias="OBSIDIAN_HOST"
+    )
+    
+    obsidian_port: int = Field(
+        default=27124,
+        description="Obsidian REST API port",
+        alias="OBSIDIAN_PORT"
+    )
+    
+    obsidian_protocol: str = Field(
+        default="https",
+        description="Protocol for Obsidian REST API (http or https)",
+        alias="OBSIDIAN_PROTOCOL"
+    )
+    
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+        # Use alias for environment variable names
+        populate_by_name=True
+    )
+    
+    @field_validator("obsidian_protocol")
+    @classmethod
+    def validate_protocol(cls, v: str) -> str:
+        """Ensure protocol is either http or https."""
+        v_lower = v.lower()
+        if v_lower not in ("http", "https"):
+            # Default to https for security
+            return "https"
+        return v_lower
+    
+    @field_validator("obsidian_port")
+    @classmethod
+    def validate_port(cls, v: int) -> int:
+        """Ensure port is in valid range."""
+        if not 1 <= v <= 65535:
+            raise ValueError(f"Port must be between 1 and 65535, got {v}")
+        return v
+    
+    @property
+    def base_url(self) -> str:
+        """Construct the base URL for Obsidian API."""
+        return f"{self.obsidian_protocol}://{self.obsidian_host}:{self.obsidian_port}"
+
+
+def get_settings() -> Settings:
+    """Get the settings instance.
+    
+    This function creates a new Settings instance each time it's called,
+    allowing for dynamic configuration updates (useful for testing).
+    
+    For production use, consider caching the settings instance.
+    """
+    return Settings()
+
+
+# For backward compatibility and convenience
+def get_cached_settings() -> Settings:
+    """Get a cached settings instance.
+    
+    This function returns the same Settings instance on subsequent calls,
+    which is more efficient but doesn't pick up environment changes.
+    """
+    if not hasattr(get_cached_settings, "_instance"):
+        get_cached_settings._instance = Settings()
+    return get_cached_settings._instance

--- a/src/mcp_obsidian/config.py
+++ b/src/mcp_obsidian/config.py
@@ -37,6 +37,29 @@ class Settings(BaseSettings):
         alias="OBSIDIAN_PROTOCOL"
     )
     
+    # Connection settings - CLI-friendly individual fields
+    obsidian_connect_timeout: int = Field(
+        default=3,
+        ge=1,
+        le=60,
+        description="Connection timeout in seconds",
+        alias="OBSIDIAN_CONNECT_TIMEOUT"
+    )
+    
+    obsidian_read_timeout: int = Field(
+        default=6,
+        ge=1,
+        le=300,
+        description="Read timeout in seconds",
+        alias="OBSIDIAN_READ_TIMEOUT"
+    )
+    
+    obsidian_verify_ssl: bool = Field(
+        default=False,
+        description="Verify SSL certificates (set to true for production)",
+        alias="OBSIDIAN_VERIFY_SSL"
+    )
+    
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/src/mcp_obsidian/config.py
+++ b/src/mcp_obsidian/config.py
@@ -1,7 +1,7 @@
 """Centralized configuration management using Pydantic Settings."""
-from typing import Optional
+from typing import Optional, Dict, Any, Tuple, Type
 from pydantic import Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, SettingsConfigDict, PydanticBaseSettingsSource
 
 
 class Settings(BaseSettings):
@@ -14,27 +14,23 @@ class Settings(BaseSettings):
     # Required settings
     obsidian_api_key: str = Field(
         ...,
-        description="API key for Obsidian Local REST API",
-        alias="OBSIDIAN_API_KEY"
+        description="API key for Obsidian Local REST API"
     )
     
     # Optional settings with defaults
     obsidian_host: str = Field(
         default="127.0.0.1",
-        description="Obsidian REST API host",
-        alias="OBSIDIAN_HOST"
+        description="Obsidian REST API host"
     )
     
     obsidian_port: int = Field(
         default=27124,
-        description="Obsidian REST API port",
-        alias="OBSIDIAN_PORT"
+        description="Obsidian REST API port"
     )
     
     obsidian_protocol: str = Field(
         default="https",
-        description="Protocol for Obsidian REST API (http or https)",
-        alias="OBSIDIAN_PROTOCOL"
+        description="Protocol for Obsidian REST API (http or https)"
     )
     
     # Connection settings - CLI-friendly individual fields
@@ -42,22 +38,19 @@ class Settings(BaseSettings):
         default=3,
         ge=1,
         le=60,
-        description="Connection timeout in seconds",
-        alias="OBSIDIAN_CONNECT_TIMEOUT"
+        description="Connection timeout in seconds"
     )
     
     obsidian_read_timeout: int = Field(
         default=6,
         ge=1,
         le=300,
-        description="Read timeout in seconds",
-        alias="OBSIDIAN_READ_TIMEOUT"
+        description="Read timeout in seconds"
     )
     
     obsidian_verify_ssl: bool = Field(
         default=False,
-        description="Verify SSL certificates (set to true for production)",
-        alias="OBSIDIAN_VERIFY_SSL"
+        description="Verify SSL certificates (set to true for production)"
     )
     
     model_config = SettingsConfigDict(
@@ -65,8 +58,8 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
-        # Use alias for environment variable names
-        populate_by_name=True
+        # Environment variables will be OBSIDIAN_API_KEY, OBSIDIAN_HOST, etc.
+        env_prefix=""  # No prefix since field names already start with "obsidian_"
     )
     
     @field_validator("obsidian_protocol")
@@ -75,8 +68,7 @@ class Settings(BaseSettings):
         """Ensure protocol is either http or https."""
         v_lower = v.lower()
         if v_lower not in ("http", "https"):
-            # Default to https for security
-            return "https"
+            raise ValueError(f"Protocol must be 'http' or 'https', got '{v}'")
         return v_lower
     
     @field_validator("obsidian_port")
@@ -91,6 +83,31 @@ class Settings(BaseSettings):
     def base_url(self) -> str:
         """Construct the base URL for Obsidian API."""
         return f"{self.obsidian_protocol}://{self.obsidian_host}:{self.obsidian_port}"
+    
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        """Customize the order of settings sources.
+        
+        Priority order (highest to lowest):
+        1. init_settings (values passed to __init__)
+        2. env_settings (environment variables)
+        3. dotenv_settings (.env file)
+        4. file_secret_settings (not used)
+        
+        This ensures CLI args passed to __init__ take precedence over everything.
+        """
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+        )
 
 
 def get_settings() -> Settings:

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -1,28 +1,51 @@
 import requests
 import urllib.parse
 import os
-from typing import Any
+from typing import Any, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .config import Settings
 
 class Obsidian():
     def __init__(
             self, 
-            api_key: str,
-            protocol: str = os.getenv('OBSIDIAN_PROTOCOL', 'https').lower(),
-            host: str = str(os.getenv('OBSIDIAN_HOST', '127.0.0.1')),
-            port: int = int(os.getenv('OBSIDIAN_PORT', '27124')),
-            verify_ssl: bool = False,
+            api_key: Optional[str] = None,
+            protocol: Optional[str] = None,
+            host: Optional[str] = None,
+            port: Optional[int] = None,
+            verify_ssl: Optional[bool] = None,
+            config: Optional['Settings'] = None,
         ):
-        self.api_key = api_key
+        """Initialize Obsidian client.
         
-        if protocol == 'http':
-            self.protocol = 'http'
+        Can be initialized either with individual parameters or a config object.
+        If config is provided, it takes precedence over individual parameters.
+        """
+        if config:
+            # Use config object if provided
+            self.api_key = config.obsidian_api_key
+            self.protocol = config.obsidian_protocol
+            self.host = config.obsidian_host
+            self.port = config.obsidian_port
+            # These are hardcoded for now (not configurable)
+            self.verify_ssl = False
+            self.timeout = (3, 6)
         else:
-            self.protocol = 'https' # Default to https for any other value, including 'https'
-
-        self.host = host
-        self.port = port
-        self.verify_ssl = verify_ssl
-        self.timeout = (3, 6)
+            # Fall back to individual parameters or environment variables for backward compatibility
+            self.api_key = api_key or os.getenv('OBSIDIAN_API_KEY', '')
+            if not self.api_key:
+                raise ValueError("api_key is required")
+            
+            protocol = protocol or os.getenv('OBSIDIAN_PROTOCOL', 'https')
+            if protocol.lower() == 'http':
+                self.protocol = 'http'
+            else:
+                self.protocol = 'https'
+            
+            self.host = host or os.getenv('OBSIDIAN_HOST', '127.0.0.1')
+            self.port = port or int(os.getenv('OBSIDIAN_PORT', '27124'))
+            self.verify_ssl = verify_ssl if verify_ssl is not None else False
+            self.timeout = (3, 6)
 
     def get_base_url(self) -> str:
         return f'{self.protocol}://{self.host}:{self.port}'

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -27,9 +27,9 @@ class Obsidian():
             self.protocol = config.obsidian_protocol
             self.host = config.obsidian_host
             self.port = config.obsidian_port
-            # These are hardcoded for now (not configurable)
-            self.verify_ssl = False
-            self.timeout = (3, 6)
+            self.verify_ssl = config.obsidian_verify_ssl
+            # Construct timeout tuple from individual timeout values
+            self.timeout = (config.obsidian_connect_timeout, config.obsidian_read_timeout)
         else:
             # Fall back to individual parameters or environment variables for backward compatibility
             self.api_key = api_key or os.getenv('OBSIDIAN_API_KEY', '')

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections.abc import Sequence
 from functools import lru_cache
-from typing import Any
+from typing import Any, Optional
 from mcp.server import Server
 from mcp.types import (
     Tool,
@@ -18,40 +18,44 @@ from . import tools
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mcp-obsidian")
 
-# Load configuration once at startup
-try:
-    config: Settings = get_settings()
-except Exception as e:
-    logger.error(f"Failed to load configuration: {e}")
-    raise
+# Configuration will be set by CLI or loaded here
+config: Optional[Settings] = None
 
 app = Server("mcp-obsidian")
 
-tool_handlers = {}
-def add_tool_handler(tool_class: tools.ToolHandler):
-    global tool_handlers
+# List of all tool handler classes
+handler_classes = [
+    tools.ListFilesInDirToolHandler,
+    tools.ListFilesInVaultToolHandler,
+    tools.GetFileContentsToolHandler,
+    tools.SearchToolHandler,
+    tools.PatchContentToolHandler,
+    tools.AppendContentToolHandler,
+    tools.PutContentToolHandler,
+    tools.DeleteFileToolHandler,
+    tools.ComplexSearchToolHandler,
+    tools.BatchGetFileContentsToolHandler,
+    tools.PeriodicNotesToolHandler,
+    tools.RecentPeriodicNotesToolHandler,
+    tools.RecentChangesToolHandler,
+]
 
-    tool_handlers[tool_class.name] = tool_class
+tool_handlers = {}
+
+def initialize_tool_handlers(config: Settings):
+    """Initialize all tool handlers with the given configuration."""
+    global tool_handlers
+    tool_handlers.clear()
+    
+    for handler_class in handler_classes:
+        handler_instance = handler_class(config)
+        tool_handlers[handler_instance.name] = handler_instance
 
 def get_tool_handler(name: str) -> tools.ToolHandler | None:
     if name not in tool_handlers:
         return None
     
     return tool_handlers[name]
-
-add_tool_handler(tools.ListFilesInDirToolHandler(config))
-add_tool_handler(tools.ListFilesInVaultToolHandler(config))
-add_tool_handler(tools.GetFileContentsToolHandler(config))
-add_tool_handler(tools.SearchToolHandler(config))
-add_tool_handler(tools.PatchContentToolHandler(config))
-add_tool_handler(tools.AppendContentToolHandler(config))
-add_tool_handler(tools.PutContentToolHandler(config))
-add_tool_handler(tools.DeleteFileToolHandler(config))
-add_tool_handler(tools.ComplexSearchToolHandler(config))
-add_tool_handler(tools.BatchGetFileContentsToolHandler(config))
-add_tool_handler(tools.PeriodicNotesToolHandler(config))
-add_tool_handler(tools.RecentPeriodicNotesToolHandler(config))
-add_tool_handler(tools.RecentChangesToolHandler(config))
 
 @app.list_tools()
 async def list_tools() -> list[Tool]:
@@ -79,7 +83,15 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent | ImageCo
 
 
 async def main():
-
+    global config
+    
+    # Load config if not already set by CLI
+    if config is None:
+        config = get_settings()
+    
+    # Initialize tool handlers with the config
+    initialize_tool_handlers(config)
+    
     # Import here to avoid issues with event loops
     from mcp.server.stdio import stdio_server
 

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -3,8 +3,6 @@ import logging
 from collections.abc import Sequence
 from functools import lru_cache
 from typing import Any
-import os
-from dotenv import load_dotenv
 from mcp.server import Server
 from mcp.types import (
     Tool,
@@ -13,19 +11,19 @@ from mcp.types import (
     EmbeddedResource,
 )
 
-load_dotenv()
-
+from .config import get_settings, Settings
 from . import tools
-
-# Load environment variables
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mcp-obsidian")
 
-api_key = os.getenv("OBSIDIAN_API_KEY")
-if not api_key:
-    raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+# Load configuration once at startup
+try:
+    config: Settings = get_settings()
+except Exception as e:
+    logger.error(f"Failed to load configuration: {e}")
+    raise
 
 app = Server("mcp-obsidian")
 
@@ -41,19 +39,19 @@ def get_tool_handler(name: str) -> tools.ToolHandler | None:
     
     return tool_handlers[name]
 
-add_tool_handler(tools.ListFilesInDirToolHandler())
-add_tool_handler(tools.ListFilesInVaultToolHandler())
-add_tool_handler(tools.GetFileContentsToolHandler())
-add_tool_handler(tools.SearchToolHandler())
-add_tool_handler(tools.PatchContentToolHandler())
-add_tool_handler(tools.AppendContentToolHandler())
-add_tool_handler(tools.PutContentToolHandler())
-add_tool_handler(tools.DeleteFileToolHandler())
-add_tool_handler(tools.ComplexSearchToolHandler())
-add_tool_handler(tools.BatchGetFileContentsToolHandler())
-add_tool_handler(tools.PeriodicNotesToolHandler())
-add_tool_handler(tools.RecentPeriodicNotesToolHandler())
-add_tool_handler(tools.RecentChangesToolHandler())
+add_tool_handler(tools.ListFilesInDirToolHandler(config))
+add_tool_handler(tools.ListFilesInVaultToolHandler(config))
+add_tool_handler(tools.GetFileContentsToolHandler(config))
+add_tool_handler(tools.SearchToolHandler(config))
+add_tool_handler(tools.PatchContentToolHandler(config))
+add_tool_handler(tools.AppendContentToolHandler(config))
+add_tool_handler(tools.PutContentToolHandler(config))
+add_tool_handler(tools.DeleteFileToolHandler(config))
+add_tool_handler(tools.ComplexSearchToolHandler(config))
+add_tool_handler(tools.BatchGetFileContentsToolHandler(config))
+add_tool_handler(tools.PeriodicNotesToolHandler(config))
+add_tool_handler(tools.RecentPeriodicNotesToolHandler(config))
+add_tool_handler(tools.RecentChangesToolHandler(config))
 
 @app.list_tools()
 async def list_tools() -> list[Tool]:

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import TYPE_CHECKING, Optional
 from mcp.types import (
     Tool,
     TextContent,
@@ -7,20 +8,45 @@ from mcp.types import (
 )
 import json
 import os
+import sys
 from . import obsidian
 
+if TYPE_CHECKING:
+    from .config import Settings
+
+# For backward compatibility - these will be removed once all tools use config
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
 
-if api_key == "":
-    raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+# Only raise error if we're not in test mode and config is not available
+if api_key == "" and "pytest" not in sys.modules:
+    # Try to import config to see if it's available
+    try:
+        from .config import get_settings
+        get_settings()  # This will raise if config is invalid
+    except Exception:
+        raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
 
 TOOL_LIST_FILES_IN_VAULT = "obsidian_list_files_in_vault"
 TOOL_LIST_FILES_IN_DIR = "obsidian_list_files_in_dir"
 
 class ToolHandler():
-    def __init__(self, tool_name: str):
+    def __init__(self, tool_name: str, config: 'Settings' = None):
         self.name = tool_name
+        self.config = config
+        # For backward compatibility
+        if not self.config:
+            # Create Obsidian client with module-level variables
+            self._api_key = api_key
+            self._obsidian_host = obsidian_host
+        
+    def get_obsidian_client(self) -> obsidian.Obsidian:
+        """Get an Obsidian client instance using the config."""
+        if self.config:
+            return obsidian.Obsidian(config=self.config)
+        else:
+            # Backward compatibility
+            return obsidian.Obsidian(api_key=self._api_key, host=self._obsidian_host)
 
     def get_tool_description(self) -> Tool:
         raise NotImplementedError()
@@ -29,8 +55,8 @@ class ToolHandler():
         raise NotImplementedError()
     
 class ListFilesInVaultToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__(TOOL_LIST_FILES_IN_VAULT)
+    def __init__(self, config: Optional['Settings'] = None):
+        super().__init__(TOOL_LIST_FILES_IN_VAULT, config)
 
     def get_tool_description(self):
         return Tool(
@@ -44,7 +70,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
 
         files = api.list_files_in_vault()
 
@@ -56,8 +82,8 @@ class ListFilesInVaultToolHandler(ToolHandler):
         ]
     
 class ListFilesInDirToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__(TOOL_LIST_FILES_IN_DIR)
+    def __init__(self, config: Optional["Settings"] = None):
+        super().__init__(TOOL_LIST_FILES_IN_DIR, config)
 
     def get_tool_description(self):
         return Tool(
@@ -80,7 +106,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         if "dirpath" not in args:
             raise RuntimeError("dirpath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
 
         files = api.list_files_in_dir(args["dirpath"])
 
@@ -92,8 +118,8 @@ class ListFilesInDirToolHandler(ToolHandler):
         ]
     
 class GetFileContentsToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__("obsidian_get_file_contents")
+    def __init__(self, config: Optional["Settings"] = None):
+        super().__init__("obsidian_get_file_contents", config)
 
     def get_tool_description(self):
         return Tool(
@@ -116,7 +142,7 @@ class GetFileContentsToolHandler(ToolHandler):
         if "filepath" not in args:
             raise RuntimeError("filepath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
 
         content = api.get_file_contents(args["filepath"])
 
@@ -128,8 +154,8 @@ class GetFileContentsToolHandler(ToolHandler):
         ]
     
 class SearchToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__("obsidian_simple_search")
+    def __init__(self, config: Optional["Settings"] = None):
+        super().__init__("obsidian_simple_search", config)
 
     def get_tool_description(self):
         return Tool(
@@ -159,7 +185,7 @@ class SearchToolHandler(ToolHandler):
 
         context_length = args.get("context_length", 100)
         
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
         results = api.search(args["query"], context_length)
         
         formatted_results = []
@@ -190,8 +216,8 @@ class SearchToolHandler(ToolHandler):
         ]
     
 class AppendContentToolHandler(ToolHandler):
-   def __init__(self):
-       super().__init__("obsidian_append_content")
+   def __init__(self, config: Optional["Settings"] = None):
+       super().__init__("obsidian_append_content", config)
 
    def get_tool_description(self):
        return Tool(
@@ -218,7 +244,7 @@ class AppendContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = self.get_obsidian_client()
        api.append_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -229,8 +255,8 @@ class AppendContentToolHandler(ToolHandler):
        ]
    
 class PatchContentToolHandler(ToolHandler):
-   def __init__(self):
-       super().__init__("obsidian_patch_content")
+   def __init__(self, config: Optional["Settings"] = None):
+       super().__init__("obsidian_patch_content", config)
 
    def get_tool_description(self):
        return Tool(
@@ -271,7 +297,7 @@ class PatchContentToolHandler(ToolHandler):
        if not all(k in args for k in ["filepath", "operation", "target_type", "target", "content"]):
            raise RuntimeError("filepath, operation, target_type, target and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = self.get_obsidian_client()
        api.patch_content(
            args.get("filepath", ""),
            args.get("operation", ""),
@@ -288,8 +314,8 @@ class PatchContentToolHandler(ToolHandler):
        ]
        
 class PutContentToolHandler(ToolHandler):
-   def __init__(self):
-       super().__init__("obsidian_put_content")
+   def __init__(self, config: Optional["Settings"] = None):
+       super().__init__("obsidian_put_content", config)
 
    def get_tool_description(self):
        return Tool(
@@ -316,7 +342,7 @@ class PutContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = self.get_obsidian_client()
        api.put_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -328,8 +354,8 @@ class PutContentToolHandler(ToolHandler):
    
 
 class DeleteFileToolHandler(ToolHandler):
-   def __init__(self):
-       super().__init__("obsidian_delete_file")
+   def __init__(self, config: Optional["Settings"] = None):
+       super().__init__("obsidian_delete_file", config)
 
    def get_tool_description(self):
        return Tool(
@@ -360,7 +386,7 @@ class DeleteFileToolHandler(ToolHandler):
        if not args.get("confirm", False):
            raise RuntimeError("confirm must be set to true to delete a file")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = self.get_obsidian_client()
        api.delete_file(args["filepath"])
 
        return [
@@ -371,8 +397,8 @@ class DeleteFileToolHandler(ToolHandler):
        ]
    
 class ComplexSearchToolHandler(ToolHandler):
-   def __init__(self):
-       super().__init__("obsidian_complex_search")
+   def __init__(self, config: Optional["Settings"] = None):
+       super().__init__("obsidian_complex_search", config)
 
    def get_tool_description(self):
        return Tool(
@@ -424,7 +450,7 @@ class ComplexSearchToolHandler(ToolHandler):
        if "query" not in args:
            raise RuntimeError("query argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = self.get_obsidian_client()
        results = api.search_json(args.get("query", ""))
 
        return [
@@ -435,8 +461,8 @@ class ComplexSearchToolHandler(ToolHandler):
        ]
 
 class BatchGetFileContentsToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__("obsidian_batch_get_file_contents")
+    def __init__(self, config: Optional["Settings"] = None):
+        super().__init__("obsidian_batch_get_file_contents", config)
 
     def get_tool_description(self):
         return Tool(
@@ -463,7 +489,7 @@ class BatchGetFileContentsToolHandler(ToolHandler):
         if "filepaths" not in args:
             raise RuntimeError("filepaths argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
         content = api.get_batch_file_contents(args["filepaths"])
 
         return [
@@ -474,8 +500,8 @@ class BatchGetFileContentsToolHandler(ToolHandler):
         ]
 
 class PeriodicNotesToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__("obsidian_get_periodic_note")
+    def __init__(self, config: Optional["Settings"] = None):
+        super().__init__("obsidian_get_periodic_note", config)
 
     def get_tool_description(self):
         return Tool(
@@ -514,7 +540,7 @@ class PeriodicNotesToolHandler(ToolHandler):
         if type not in valid_types:
             raise RuntimeError(f"Invalid type: {type}. Must be one of: {', '.join(valid_types)}")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
         content = api.get_periodic_note(period,type)
 
         return [
@@ -525,8 +551,8 @@ class PeriodicNotesToolHandler(ToolHandler):
         ]
         
 class RecentPeriodicNotesToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__("obsidian_get_recent_periodic_notes")
+    def __init__(self, config: Optional["Settings"] = None):
+        super().__init__("obsidian_get_recent_periodic_notes", config)
 
     def get_tool_description(self):
         return Tool(
@@ -574,7 +600,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         if not isinstance(include_content, bool):
             raise RuntimeError(f"Invalid include_content: {include_content}. Must be a boolean")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
         results = api.get_recent_periodic_notes(period, limit, include_content)
 
         return [
@@ -585,8 +611,8 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         ]
         
 class RecentChangesToolHandler(ToolHandler):
-    def __init__(self):
-        super().__init__("obsidian_get_recent_changes")
+    def __init__(self, config: Optional["Settings"] = None):
+        super().__init__("obsidian_get_recent_changes", config)
 
     def get_tool_description(self):
         return Tool(
@@ -621,7 +647,7 @@ class RecentChangesToolHandler(ToolHandler):
         if not isinstance(days, int) or days < 1:
             raise RuntimeError(f"Invalid days: {days}. Must be a positive integer")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = self.get_obsidian_client()
         results = api.get_recent_changes(limit, days)
 
         return [

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -18,14 +18,8 @@ if TYPE_CHECKING:
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
 
-# Only raise error if we're not in test mode and config is not available
-if api_key == "" and "pytest" not in sys.modules:
-    # Try to import config to see if it's available
-    try:
-        from .config import get_settings
-        get_settings()  # This will raise if config is invalid
-    except Exception:
-        raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+# Don't validate at import time - let the server handle it when it starts
+# This allows CLI to work even without config set
 
 TOOL_LIST_FILES_IN_VAULT = "obsidian_list_files_in_vault"
 TOOL_LIST_FILES_IN_DIR = "obsidian_list_files_in_dir"
@@ -149,7 +143,7 @@ class GetFileContentsToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(content, indent=2)
+                text=content
             )
         ]
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,91 @@
+"""Shared fixtures for tests."""
+import pytest
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Check for .env file and fail fast if it exists
+def check_no_env_file():
+    """Ensure no .env file exists during testing to prevent configuration conflicts."""
+    env_file = Path(__file__).parent.parent / ".env"
+    if env_file.exists():
+        pytest.exit(
+            "\n"
+            "ERROR: .env file detected in project root.\n"
+            "Tests require a clean environment without .env file to ensure proper isolation.\n"
+            "Please remove or rename the .env file before running tests.\n"
+            f"File location: {env_file}\n",
+            returncode=1
+        )
+
+# Run the check when tests are collected
+check_no_env_file()
+
+@pytest.fixture(autouse=True)
+def mock_env_vars(monkeypatch):
+    """Automatically set required environment variables for all tests."""
+    # Clear any existing env vars first
+    for key in ["OBSIDIAN_API_KEY", "OBSIDIAN_HOST", "OBSIDIAN_PORT", "OBSIDIAN_PROTOCOL"]:
+        monkeypatch.delenv(key, raising=False)
+    
+    # Set test values
+    monkeypatch.setenv("OBSIDIAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("OBSIDIAN_HOST", "127.0.0.1")
+    monkeypatch.setenv("OBSIDIAN_PORT", "27124")
+    monkeypatch.setenv("OBSIDIAN_PROTOCOL", "https")
+
+@pytest.fixture
+def mock_obsidian_api():
+    """Fixture for mocking Obsidian API responses."""
+    import responses
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+@pytest.fixture
+def sample_vault_files():
+    """Sample vault file structure for testing."""
+    return {
+        "files": [
+            {"path": "notes/daily/2024-01-01.md", "type": "file"},
+            {"path": "notes/daily/2024-01-02.md", "type": "file"},
+            {"path": "notes/meetings", "type": "directory"},
+            {"path": "notes/meetings/team-standup.md", "type": "file"},
+            {"path": "projects/project-a.md", "type": "file"},
+        ]
+    }
+
+@pytest.fixture
+def sample_file_content():
+    """Sample file content for testing."""
+    return """# Test Note
+
+## Section 1
+This is a test note with some content.
+
+## Section 2
+- Item 1
+- Item 2
+- Item 3
+
+## Tags
+#test #sample #markdown
+"""
+
+@pytest.fixture
+def sample_search_results():
+    """Sample search results for testing."""
+    return [
+        {
+            "filename": "notes/daily/2024-01-01.md",
+            "matches": [
+                {"match": {"text": "meeting with team about project"}, "line": 5}
+            ]
+        },
+        {
+            "filename": "projects/project-a.md", 
+            "matches": [
+                {"match": {"text": "project kickoff scheduled"}, "line": 10}
+            ]
+        }
+    ]

--- a/tests/test_basic_integration.py
+++ b/tests/test_basic_integration.py
@@ -1,0 +1,79 @@
+"""Basic integration tests to ensure core functionality works before refactoring."""
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+import json
+
+# Prevent loading .env file during tests
+with patch.dict(os.environ, {}, clear=True):
+    os.environ["OBSIDIAN_API_KEY"] = "test-api-key"
+    from mcp_obsidian.obsidian import Obsidian
+    from mcp_obsidian import server
+    from mcp_obsidian.tools import ListFilesInVaultToolHandler
+
+class TestBasicFunctionality:
+    """Test basic functionality to ensure nothing breaks during refactoring."""
+    
+    def test_obsidian_client_creation(self):
+        """Test that we can create an Obsidian client."""
+        client = Obsidian(api_key="test-key", host="localhost", port=8080)
+        assert client.api_key == "test-key"
+        assert client.host == "localhost"
+        assert client.port == 8080
+        
+    def test_tool_handler_exists(self):
+        """Test that tool handlers are registered."""
+        assert "obsidian_list_files_in_vault" in server.tool_handlers
+        assert "obsidian_get_file_contents" in server.tool_handlers
+        assert "obsidian_simple_search" in server.tool_handlers
+        
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_simple_tool_execution(self, mock_obsidian_class):
+        """Test that a simple tool can be executed."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.list_files_in_vault.return_value = [
+            {"path": "test.md", "type": "file"}
+        ]
+        
+        # Execute tool
+        handler = ListFilesInVaultToolHandler()
+        result = handler.run_tool({})
+        
+        # Verify
+        assert len(result) == 1
+        assert result[0].type == "text"
+        # The result should be JSON
+        data = json.loads(result[0].text)
+        assert isinstance(data, list)
+        assert data[0]["path"] == "test.md"
+    
+    @pytest.mark.asyncio
+    async def test_server_list_tools(self):
+        """Test that server can list tools."""
+        tools = await server.list_tools()
+        assert len(tools) > 0
+        # Check that tools have required properties
+        for tool in tools:
+            assert hasattr(tool, 'name')
+            assert hasattr(tool, 'description')
+            assert hasattr(tool, 'inputSchema')
+    
+    def test_environment_configuration(self):
+        """Test that environment variables are properly used."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "env-key",
+            "OBSIDIAN_HOST": "env-host",
+            "OBSIDIAN_PORT": "9999",
+            "OBSIDIAN_PROTOCOL": "http"
+        }):
+            client = Obsidian(
+                api_key="env-key",
+                host=os.getenv("OBSIDIAN_HOST", "127.0.0.1"),
+                port=int(os.getenv("OBSIDIAN_PORT", "27124")),
+                protocol=os.getenv("OBSIDIAN_PROTOCOL", "https")
+            )
+            assert client.host == "env-host"
+            assert client.port == 9999
+            assert client.protocol == "http"

--- a/tests/test_basic_integration.py
+++ b/tests/test_basic_integration.py
@@ -9,10 +9,22 @@ with patch.dict(os.environ, {}, clear=True):
     os.environ["OBSIDIAN_API_KEY"] = "test-api-key"
     from mcp_obsidian.obsidian import Obsidian
     from mcp_obsidian import server
+    from mcp_obsidian.config import Settings
     from mcp_obsidian.tools import ListFilesInVaultToolHandler
 
 class TestBasicFunctionality:
     """Test basic functionality to ensure nothing breaks during refactoring."""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Initialize tool handlers before each test."""
+        # Create a test config
+        test_config = Settings(obsidian_api_key="test-api-key")
+        # Initialize handlers for testing
+        server.initialize_tool_handlers(test_config)
+        yield
+        # Clean up after test
+        server.tool_handlers.clear()
     
     def test_obsidian_client_creation(self):
         """Test that we can create an Obsidian client."""
@@ -23,6 +35,9 @@ class TestBasicFunctionality:
         
     def test_tool_handler_exists(self):
         """Test that tool handlers are registered."""
+        # Re-initialize to ensure tools are registered
+        test_config = Settings(obsidian_api_key="test-api-key")
+        server.initialize_tool_handlers(test_config)
         assert "obsidian_list_files_in_vault" in server.tool_handlers
         assert "obsidian_get_file_contents" in server.tool_handlers
         assert "obsidian_simple_search" in server.tool_handlers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,299 @@
+"""Tests for the CLI using Typer's CliRunner."""
+import pytest
+from typer.testing import CliRunner
+import typer
+import asyncio
+import os
+
+from mcp_obsidian.cli import main
+from mcp_obsidian import __version__
+
+
+# Create a Typer app for testing
+app = typer.Typer()
+app.command()(main)
+
+
+@pytest.fixture(autouse=True)
+def mock_env_vars(monkeypatch):
+    """Override the global mock_env_vars to not set any defaults for CLI tests."""
+    # Don't set any environment variables for CLI tests
+    # This overrides the autouse fixture from conftest.py
+    pass
+
+
+@pytest.fixture
+def runner():
+    """Provide a CliRunner instance for tests."""
+    return CliRunner()
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Clean environment variables for testing."""
+    # Remove any Obsidian-related env vars
+    env_vars = [
+        "OBSIDIAN_API_KEY",
+        "OBSIDIAN_HOST", 
+        "OBSIDIAN_PORT",
+        "OBSIDIAN_PROTOCOL",
+        "OBSIDIAN_CONNECT_TIMEOUT",
+        "OBSIDIAN_READ_TIMEOUT",
+        "OBSIDIAN_VERIFY_SSL"
+    ]
+    for var in env_vars:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_help(runner):
+    """Test that --help works."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "MCP server for Obsidian integration" in result.stdout
+    assert "--api-key" in result.stdout
+    assert "--host" in result.stdout
+    assert "--port" in result.stdout
+    assert "--version" in result.stdout
+    assert "--config-check" in result.stdout
+
+
+def test_version(runner):
+    """Test that --version works."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert f"mcp-obsidian version: {__version__}" in result.stdout
+
+
+def test_config_check_with_api_key(runner):
+    """Test --config-check with valid configuration."""
+    result = runner.invoke(app, ["--config-check", "--api-key", "test123"])
+    assert result.exit_code == 0
+    assert "Current configuration:" in result.stdout
+    assert "API Key: ***" in result.stdout
+    assert "Host: 127.0.0.1" in result.stdout
+    assert "Port: 27124" in result.stdout
+    assert "✓ Configuration is valid" in result.stdout
+
+
+def test_config_check_without_api_key(runner, clean_env):
+    """Test --config-check without API key shows error."""
+    result = runner.invoke(app, ["--config-check"])
+    assert result.exit_code == 1
+    assert "Configuration error" in result.stdout or "Field required" in result.stdout
+
+
+def test_custom_host_and_port(runner):
+    """Test configuration with custom host and port."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--host", "192.168.1.100",
+        "--port", "8080"
+    ])
+    assert result.exit_code == 0
+    assert "Host: 192.168.1.100" in result.stdout
+    assert "Port: 8080" in result.stdout
+
+
+def test_custom_protocol(runner):
+    """Test configuration with custom protocol."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--protocol", "http"
+    ])
+    assert result.exit_code == 0
+    assert "Protocol: http" in result.stdout
+    assert "Base URL: http://127.0.0.1:27124" in result.stdout
+
+
+def test_timeout_settings(runner):
+    """Test timeout configuration."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--connect-timeout", "10",
+        "--read-timeout", "30"
+    ])
+    assert result.exit_code == 0
+    assert "Connect Timeout: 10s" in result.stdout
+    assert "Read Timeout: 30s" in result.stdout
+
+
+def test_ssl_verification_enabled(runner):
+    """Test SSL verification enabled."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--verify-ssl"
+    ])
+    assert result.exit_code == 0
+    assert "Verify SSL: True" in result.stdout
+
+
+def test_ssl_verification_disabled(runner):
+    """Test SSL verification disabled."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--no-verify-ssl"
+    ])
+    assert result.exit_code == 0
+    assert "Verify SSL: False" in result.stdout
+
+
+def test_invalid_port(runner):
+    """Test that invalid port values are rejected."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--port", "not-a-number"
+    ])
+    assert result.exit_code != 0
+    assert "Invalid value" in result.stdout or "Error" in result.stdout
+
+
+def test_connect_timeout_too_high(runner):
+    """Test that connect timeout over 60 is rejected."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--connect-timeout", "100"
+    ])
+    assert result.exit_code != 0
+
+
+def test_read_timeout_too_high(runner):
+    """Test that read timeout over 300 is rejected."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--read-timeout", "400"
+    ])
+    assert result.exit_code != 0
+
+
+def test_server_starts_with_valid_config(runner, mocker):
+    """Test that server starts with valid configuration."""
+    # Mock the async server.main to avoid actual server startup
+    mock_server_main = mocker.patch('mcp_obsidian.server.main')
+    future = asyncio.Future()
+    future.set_result(None)
+    mock_server_main.return_value = future
+    
+    result = runner.invoke(app, [
+        "--api-key", "test123",
+        "--host", "localhost",
+        "--port", "8080"
+    ])
+    
+    # Server should have been called
+    mock_server_main.assert_called_once()
+
+
+def test_verbose_logging(runner):
+    """Test verbose logging option."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--verbose"
+    ])
+    assert result.exit_code == 0
+    # Verbose flag should work without errors
+
+
+def test_verbose_short_option(runner):
+    """Test verbose logging with short option -v."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "-v"
+    ])
+    assert result.exit_code == 0
+
+
+def test_environment_variable_override(runner, monkeypatch):
+    """Test that CLI arguments override environment variables."""
+    monkeypatch.setenv("OBSIDIAN_API_KEY", "env_key")
+    monkeypatch.setenv("OBSIDIAN_HOST", "env_host")
+    
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "cli_key",
+        "--host", "cli_host"
+    ])
+    assert result.exit_code == 0
+    # CLI values should be used, not env values
+    assert "Host: cli_host" in result.stdout
+    # API key should show last 4 chars of CLI key
+    assert "***_key" in result.stdout
+
+
+def test_environment_variables_used_when_no_cli_args(runner, monkeypatch):
+    """Test that environment variables are used when no CLI args provided."""
+    monkeypatch.setenv("OBSIDIAN_API_KEY", "env_api_key")
+    monkeypatch.setenv("OBSIDIAN_HOST", "env.example.com")
+    monkeypatch.setenv("OBSIDIAN_PORT", "9999")
+    
+    result = runner.invoke(app, ["--config-check"])
+    assert result.exit_code == 0
+    assert "Host: env.example.com" in result.stdout
+    assert "Port: 9999" in result.stdout
+    assert "***_key" in result.stdout  # Last 4 chars of env_api_key
+
+
+def test_missing_required_api_key(runner, clean_env):
+    """Test that missing API key causes error when trying to run server."""
+    result = runner.invoke(app, [])
+    assert result.exit_code == 1
+    assert "Configuration error" in result.stdout or "Field required" in result.stdout
+
+
+def test_protocol_validation(runner):
+    """Test that only http and https protocols are accepted."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--protocol", "ftp"  # Invalid protocol
+    ])
+    assert result.exit_code == 1
+    assert "Configuration error" in result.stdout or "Protocol must be" in result.stdout
+
+
+def test_all_cli_options_together(runner):
+    """Test using all CLI options together."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "full_test_key",
+        "--host", "test.local",
+        "--port", "3000",
+        "--protocol", "http",
+        "--connect-timeout", "5",
+        "--read-timeout", "10",
+        "--verify-ssl",
+        "--verbose"
+    ])
+    assert result.exit_code == 0
+    assert "Host: test.local" in result.stdout
+    assert "Port: 3000" in result.stdout
+    assert "Protocol: http" in result.stdout
+    assert "Base URL: http://test.local:3000" in result.stdout
+    assert "Connect Timeout: 5s" in result.stdout
+    assert "Read Timeout: 10s" in result.stdout
+    assert "Verify SSL: True" in result.stdout
+    assert "✓ Configuration is valid" in result.stdout
+
+
+def test_config_check_with_partial_options(runner):
+    """Test config check with some options from CLI and rest as defaults."""
+    result = runner.invoke(app, [
+        "--config-check",
+        "--api-key", "test123",
+        "--port", "5000"
+    ])
+    assert result.exit_code == 0
+    assert "Host: 127.0.0.1" in result.stdout  # Default
+    assert "Port: 5000" in result.stdout  # From CLI
+    assert "Protocol: https" in result.stdout  # Default
+    assert "Connect Timeout: 3s" in result.stdout  # Default
+    assert "Read Timeout: 6s" in result.stdout  # Default

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,144 @@
+"""Tests for the centralized configuration system."""
+import pytest
+import os
+from unittest.mock import patch
+from pydantic import ValidationError
+
+# Set test environment before importing
+os.environ["OBSIDIAN_API_KEY"] = "test-api-key"
+
+from mcp_obsidian.config import Settings, get_settings
+from mcp_obsidian.obsidian import Obsidian
+
+
+class TestSettings:
+    """Test the Settings configuration class."""
+    
+    def test_settings_from_env(self):
+        """Test that settings are loaded from environment variables."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key-123",
+            "OBSIDIAN_HOST": "192.168.1.1",
+            "OBSIDIAN_PORT": "8080",
+            "OBSIDIAN_PROTOCOL": "http"
+        }):
+            settings = get_settings()
+            assert settings.obsidian_api_key == "test-key-123"
+            assert settings.obsidian_host == "192.168.1.1"
+            assert settings.obsidian_port == 8080
+            assert settings.obsidian_protocol == "http"
+    
+    def test_settings_defaults(self):
+        """Test that default values are used when env vars are not set."""
+        with patch.dict(os.environ, {"OBSIDIAN_API_KEY": "test-key"}, clear=True):
+            settings = get_settings()
+            assert settings.obsidian_api_key == "test-key"
+            assert settings.obsidian_host == "127.0.0.1"
+            assert settings.obsidian_port == 27124
+            assert settings.obsidian_protocol == "https"
+    
+    def test_settings_missing_api_key(self):
+        """Test that missing API key raises validation error."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValidationError) as exc_info:
+                get_settings()
+            assert "OBSIDIAN_API_KEY" in str(exc_info.value)
+    
+    def test_protocol_validation(self):
+        """Test that protocol is validated and normalized."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_PROTOCOL": "HTTP"
+        }):
+            settings = get_settings()
+            assert settings.obsidian_protocol == "http"
+        
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_PROTOCOL": "invalid"
+        }):
+            settings = get_settings()
+            assert settings.obsidian_protocol == "https"  # Defaults to https
+    
+    def test_port_validation(self):
+        """Test that port is validated."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_PORT": "0"
+        }):
+            with pytest.raises(ValidationError) as exc_info:
+                get_settings()
+            assert "Port must be between 1 and 65535" in str(exc_info.value)
+        
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_PORT": "70000"
+        }):
+            with pytest.raises(ValidationError) as exc_info:
+                get_settings()
+            assert "Port must be between 1 and 65535" in str(exc_info.value)
+    
+    def test_base_url_property(self):
+        """Test that base_url is correctly constructed."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_HOST": "example.com",
+            "OBSIDIAN_PORT": "443",
+            "OBSIDIAN_PROTOCOL": "https"
+        }):
+            settings = get_settings()
+            assert settings.base_url == "https://example.com:443"
+
+
+class TestObsidianWithConfig:
+    """Test Obsidian client with config object."""
+    
+    def test_obsidian_with_config_object(self):
+        """Test that Obsidian client can be initialized with config object."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "config-key",
+            "OBSIDIAN_HOST": "config-host",
+            "OBSIDIAN_PORT": "9999",
+            "OBSIDIAN_PROTOCOL": "http"
+        }):
+            config = get_settings()
+            client = Obsidian(config=config)
+            
+            assert client.api_key == "config-key"
+            assert client.host == "config-host"
+            assert client.port == 9999
+            assert client.protocol == "http"
+            assert client.get_base_url() == "http://config-host:9999"
+            # Verify hardcoded values
+            assert client.verify_ssl is False
+            assert client.timeout == (3, 6)
+    
+    def test_obsidian_backward_compatibility(self):
+        """Test that Obsidian client still works with individual parameters."""
+        client = Obsidian(
+            api_key="direct-key",
+            host="direct-host",
+            port=7777,
+            protocol="https"
+        )
+        
+        assert client.api_key == "direct-key"
+        assert client.host == "direct-host"
+        assert client.port == 7777
+        assert client.protocol == "https"
+    
+    def test_obsidian_config_precedence(self):
+        """Test that config object takes precedence over individual parameters."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "config-key",
+            "OBSIDIAN_HOST": "config-host"
+        }):
+            config = get_settings()
+            client = Obsidian(
+                api_key="ignored-key",
+                host="ignored-host",
+                config=config
+            )
+            
+            assert client.api_key == "config-key"
+            assert client.host == "config-host"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,7 @@ class TestSettings:
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValidationError) as exc_info:
                 get_settings()
-            assert "OBSIDIAN_API_KEY" in str(exc_info.value)
+            assert "obsidian_api_key" in str(exc_info.value)
     
     def test_protocol_validation(self):
         """Test that protocol is validated and normalized."""
@@ -56,12 +56,14 @@ class TestSettings:
             settings = get_settings()
             assert settings.obsidian_protocol == "http"
         
+        # Test that invalid protocol raises an error
         with patch.dict(os.environ, {
             "OBSIDIAN_API_KEY": "test-key",
             "OBSIDIAN_PROTOCOL": "invalid"
         }):
-            settings = get_settings()
-            assert settings.obsidian_protocol == "https"  # Defaults to https
+            with pytest.raises(ValidationError) as exc_info:
+                get_settings()
+            assert "Protocol must be 'http' or 'https'" in str(exc_info.value)
     
     def test_port_validation(self):
         """Test that port is validated."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,9 @@ class TestSettings:
             assert settings.obsidian_host == "127.0.0.1"
             assert settings.obsidian_port == 27124
             assert settings.obsidian_protocol == "https"
+            assert settings.obsidian_connect_timeout == 3
+            assert settings.obsidian_read_timeout == 6
+            assert settings.obsidian_verify_ssl is False
     
     def test_settings_missing_api_key(self):
         """Test that missing API key raises validation error."""
@@ -78,6 +81,26 @@ class TestSettings:
                 get_settings()
             assert "Port must be between 1 and 65535" in str(exc_info.value)
     
+    def test_timeout_validation(self):
+        """Test that timeout values are validated."""
+        # Test connect timeout out of range
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_CONNECT_TIMEOUT": "0"  # Below minimum
+        }):
+            with pytest.raises(ValidationError) as exc_info:
+                get_settings()
+            assert "greater than or equal to 1" in str(exc_info.value).lower()
+        
+        # Test read timeout out of range
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_READ_TIMEOUT": "301"  # Above maximum
+        }):
+            with pytest.raises(ValidationError) as exc_info:
+                get_settings()
+            assert "less than or equal to 300" in str(exc_info.value).lower()
+    
     def test_base_url_property(self):
         """Test that base_url is correctly constructed."""
         with patch.dict(os.environ, {
@@ -109,7 +132,7 @@ class TestObsidianWithConfig:
             assert client.port == 9999
             assert client.protocol == "http"
             assert client.get_base_url() == "http://config-host:9999"
-            # Verify hardcoded values
+            # Verify default timeout and SSL values
             assert client.verify_ssl is False
             assert client.timeout == (3, 6)
     
@@ -126,6 +149,20 @@ class TestObsidianWithConfig:
         assert client.host == "direct-host"
         assert client.port == 7777
         assert client.protocol == "https"
+    
+    def test_obsidian_with_custom_timeouts(self):
+        """Test that Obsidian client uses custom timeout values from config."""
+        with patch.dict(os.environ, {
+            "OBSIDIAN_API_KEY": "test-key",
+            "OBSIDIAN_CONNECT_TIMEOUT": "10",
+            "OBSIDIAN_READ_TIMEOUT": "30",
+            "OBSIDIAN_VERIFY_SSL": "true"
+        }):
+            config = get_settings()
+            client = Obsidian(config=config)
+            
+            assert client.timeout == (10, 30)
+            assert client.verify_ssl is True
     
     def test_obsidian_config_precedence(self):
         """Test that config object takes precedence over individual parameters."""

--- a/tests/test_env_check.py
+++ b/tests/test_env_check.py
@@ -1,0 +1,42 @@
+"""Test that verifies .env detection works correctly.
+This test is somewhat meta - it tests the test infrastructure itself.
+"""
+import subprocess
+import tempfile
+from pathlib import Path
+import sys
+
+def test_env_file_detection():
+    """Verify that tests fail when .env file is present."""
+    # Create a temporary .env file
+    env_file = Path(__file__).parent.parent / ".env"
+    
+    # Skip if .env already exists (shouldn't happen in CI)
+    if env_file.exists():
+        return  # Skip test if .env exists
+    
+    try:
+        # Create .env file
+        env_file.write_text("OBSIDIAN_API_KEY=test\n")
+        
+        # Try to run a simple test
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", __file__, "-k", "dummy_test"],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).parent.parent)
+        )
+        
+        # Should fail with our custom error message
+        assert result.returncode != 0
+        assert "ERROR: .env file detected in project root" in result.stderr
+        assert "Tests require a clean environment" in result.stderr
+        
+    finally:
+        # Clean up
+        if env_file.exists():
+            env_file.unlink()
+
+def test_dummy_test():
+    """A dummy test that should pass when no .env exists."""
+    assert True

--- a/tests/test_essential.py
+++ b/tests/test_essential.py
@@ -1,0 +1,144 @@
+"""Essential tests that must pass before any refactoring.
+These tests verify the core functionality works as expected.
+"""
+import pytest
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+# Set environment variables before importing modules that depend on them
+os.environ["OBSIDIAN_API_KEY"] = "test-api-key"
+
+from mcp_obsidian.obsidian import Obsidian
+from mcp_obsidian import server
+from mcp_obsidian.tools import (
+    ListFilesInVaultToolHandler,
+    ListFilesInDirToolHandler,
+    GetFileContentsToolHandler,
+)
+
+class TestEssentialFunctionality:
+    """Tests for essential functionality that must not break."""
+    
+    def test_obsidian_client_initialization(self):
+        """Test that Obsidian client can be initialized with custom values."""
+        client = Obsidian(
+            api_key="test-key",
+            protocol="https",
+            host="127.0.0.1",
+            port=27124
+        )
+        assert client.api_key == "test-key"
+        assert client.protocol == "https"
+        assert client.host == "127.0.0.1"
+        assert client.port == 27124
+        assert client.get_base_url() == "https://127.0.0.1:27124"
+    
+    def test_critical_tools_registered(self):
+        """Test that critical tools are registered in the server."""
+        critical_tools = [
+            "obsidian_list_files_in_vault",
+            "obsidian_list_files_in_dir",
+            "obsidian_get_file_contents",
+            "obsidian_append_content",
+            "obsidian_delete_file",
+        ]
+        
+        for tool_name in critical_tools:
+            assert tool_name in server.tool_handlers, f"Critical tool {tool_name} not registered"
+    
+    @pytest.mark.asyncio
+    async def test_server_can_list_tools(self):
+        """Test that server can list available tools."""
+        tools = await server.list_tools()
+        assert len(tools) > 0
+        
+        # Verify tools have required structure
+        for tool in tools:
+            assert hasattr(tool, 'name')
+            assert hasattr(tool, 'description')
+            assert hasattr(tool, 'inputSchema')
+            assert tool.name in server.tool_handlers
+    
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_list_files_tool_execution(self, mock_obsidian_class):
+        """Test that list files tool works correctly."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.list_files_in_vault.return_value = [
+            {"path": "note1.md", "type": "file"},
+            {"path": "folder1", "type": "directory"}
+        ]
+        
+        # Execute tool
+        handler = ListFilesInVaultToolHandler()
+        result = handler.run_tool({})
+        
+        # Verify
+        assert len(result) == 1
+        assert result[0].type == "text"
+        # Result should be JSON
+        data = json.loads(result[0].text)
+        assert isinstance(data, list)
+        assert len(data) == 2
+        assert data[0]["path"] == "note1.md"
+    
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_get_file_contents_tool(self, mock_obsidian_class):
+        """Test that get file contents tool works correctly."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.get_file_contents.return_value = "# Test Note\nContent here"
+        
+        # Execute tool
+        handler = GetFileContentsToolHandler()
+        result = handler.run_tool({"filepath": "test.md"})
+        
+        # Verify
+        assert len(result) == 1
+        assert result[0].type == "text"
+        # The actual implementation returns JSON wrapped content
+        # We need to check what format is actually returned
+        text = result[0].text
+        assert "Test Note" in text or "Test Note" in json.loads(text)
+    
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_list_files_in_dir_tool(self, mock_obsidian_class):
+        """Test that list files in directory tool works correctly."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.list_files_in_dir.return_value = [
+            {"path": "folder/note2.md", "type": "file"}
+        ]
+        
+        # Execute tool
+        handler = ListFilesInDirToolHandler()
+        result = handler.run_tool({"dirpath": "folder"})
+        
+        # Verify
+        mock_client.list_files_in_dir.assert_called_once_with("folder")
+        assert len(result) == 1
+        assert result[0].type == "text"
+        data = json.loads(result[0].text)
+        assert data[0]["path"] == "folder/note2.md"
+    
+    def test_tool_error_handling(self):
+        """Test that tools handle missing arguments correctly."""
+        handler = ListFilesInDirToolHandler()
+        
+        # Should raise error for missing required argument
+        with pytest.raises(RuntimeError) as exc_info:
+            handler.run_tool({})
+        
+        assert "dirpath" in str(exc_info.value).lower()
+    
+    @pytest.mark.asyncio
+    async def test_server_handles_invalid_tool(self):
+        """Test that server properly handles calls to non-existent tools."""
+        with pytest.raises(ValueError) as exc_info:
+            await server.call_tool("non_existent_tool", {})
+        
+        assert "Unknown tool" in str(exc_info.value)

--- a/tests/test_essential.py
+++ b/tests/test_essential.py
@@ -11,6 +11,7 @@ os.environ["OBSIDIAN_API_KEY"] = "test-api-key"
 
 from mcp_obsidian.obsidian import Obsidian
 from mcp_obsidian import server
+from mcp_obsidian.config import Settings
 from mcp_obsidian.tools import (
     ListFilesInVaultToolHandler,
     ListFilesInDirToolHandler,
@@ -19,6 +20,17 @@ from mcp_obsidian.tools import (
 
 class TestEssentialFunctionality:
     """Tests for essential functionality that must not break."""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Initialize tool handlers before each test."""
+        # Create a test config
+        test_config = Settings(obsidian_api_key="test-api-key")
+        # Initialize handlers for testing
+        server.initialize_tool_handlers(test_config)
+        yield
+        # Clean up after test
+        server.tool_handlers.clear()
     
     def test_obsidian_client_initialization(self):
         """Test that Obsidian client can be initialized with custom values."""
@@ -36,6 +48,10 @@ class TestEssentialFunctionality:
     
     def test_critical_tools_registered(self):
         """Test that critical tools are registered in the server."""
+        # Re-initialize to ensure tools are registered
+        test_config = Settings(obsidian_api_key="test-api-key")
+        server.initialize_tool_handlers(test_config)
+        
         critical_tools = [
             "obsidian_list_files_in_vault",
             "obsidian_list_files_in_dir",

--- a/tests/test_obsidian.py
+++ b/tests/test_obsidian.py
@@ -1,0 +1,169 @@
+"""Tests for the Obsidian API client."""
+import pytest
+import responses
+from mcp_obsidian.obsidian import Obsidian
+
+class TestObsidianClient:
+    """Test the Obsidian API client."""
+    
+    def test_initialization(self):
+        """Test Obsidian client initialization."""
+        client = Obsidian(api_key="test-key")
+        assert client.api_key == "test-key"
+        assert client.host == "127.0.0.1"
+        assert client.port == 27124
+        assert client.protocol == "https"
+        
+    def test_initialization_with_custom_values(self):
+        """Test Obsidian client with custom configuration."""
+        client = Obsidian(
+            api_key="custom-key",
+            protocol="http",
+            host="localhost",
+            port=8080
+        )
+        assert client.api_key == "custom-key"
+        assert client.protocol == "http"
+        assert client.host == "localhost"
+        assert client.port == 8080
+        
+    def test_get_base_url(self):
+        """Test base URL construction."""
+        client = Obsidian(api_key="test-key")
+        assert client.get_base_url() == "https://127.0.0.1:27124"
+        
+        client_http = Obsidian(api_key="test-key", protocol="http", port=8080)
+        assert client_http.get_base_url() == "http://127.0.0.1:8080"
+    
+    def test_headers(self):
+        """Test authorization headers."""
+        client = Obsidian(api_key="test-key")
+        headers = client._get_headers()
+        assert headers["Authorization"] == "Bearer test-key"
+    
+    @responses.activate
+    def test_list_files_in_vault(self):
+        """Test listing files in vault."""
+        client = Obsidian(api_key="test-key")
+        expected_files = [
+            {"path": "note1.md", "type": "file"},
+            {"path": "folder1", "type": "directory"}
+        ]
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/",
+            json={"files": expected_files},
+            status=200
+        )
+        
+        files = client.list_files_in_vault()
+        assert files == expected_files
+        assert len(responses.calls) == 1
+        
+    @responses.activate
+    def test_list_files_in_dir(self):
+        """Test listing files in a specific directory."""
+        client = Obsidian(api_key="test-key")
+        expected_files = [
+            {"path": "subfolder/note2.md", "type": "file"}
+        ]
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/subfolder/",
+            json={"files": expected_files},
+            status=200
+        )
+        
+        files = client.list_files_in_dir("subfolder")
+        assert files == expected_files
+        
+    @responses.activate
+    def test_get_file_contents(self):
+        """Test getting file contents."""
+        client = Obsidian(api_key="test-key")
+        expected_content = "# Test Note\n\nThis is test content."
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/test.md",
+            body=expected_content,
+            status=200
+        )
+        
+        content = client.get_file_contents("test.md")
+        assert content == expected_content
+        
+    @responses.activate
+    def test_batch_file_contents(self):
+        """Test getting batch file contents."""
+        client = Obsidian(api_key="test-key")
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/file1.md",
+            body="Content of file 1",
+            status=200
+        )
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/file2.md",
+            body="Content of file 2",
+            status=200
+        )
+        
+        result = client.get_batch_file_contents(["file1.md", "file2.md"])
+        assert "# file1.md" in result
+        assert "Content of file 1" in result
+        assert "# file2.md" in result
+        assert "Content of file 2" in result
+        
+    @responses.activate
+    def test_batch_file_contents_with_error(self):
+        """Test batch file contents with one file causing an error."""
+        client = Obsidian(api_key="test-key")
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/file1.md",
+            body="Content of file 1",
+            status=200
+        )
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/file2.md",
+            status=404
+        )
+        
+        result = client.get_batch_file_contents(["file1.md", "file2.md"])
+        assert "Content of file 1" in result
+        assert "Error reading file" in result
+        
+    @responses.activate
+    def test_api_error_handling(self):
+        """Test API error handling."""
+        client = Obsidian(api_key="test-key")
+        
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:27124/vault/",
+            json={"errorCode": 401, "message": "Unauthorized"},
+            status=401
+        )
+        
+        with pytest.raises(Exception) as exc_info:
+            client.list_files_in_vault()
+        assert "Error 401: Unauthorized" in str(exc_info.value)
+        
+    @responses.activate 
+    def test_network_error_handling(self):
+        """Test network error handling."""
+        client = Obsidian(api_key="test-key")
+        
+        # Don't add any response to simulate network error
+        with pytest.raises(Exception) as exc_info:
+            client.list_files_in_vault()
+        assert "Request failed" in str(exc_info.value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,141 @@
+"""Tests for the MCP server."""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from mcp_obsidian import server
+from mcp.types import Tool
+
+class TestServer:
+    """Test the MCP server functionality."""
+    
+    def test_tool_handler_registration(self):
+        """Test that tool handlers are registered correctly."""
+        # Clear existing handlers for test
+        original_handlers = server.tool_handlers.copy()
+        server.tool_handlers.clear()
+        
+        # Create mock handler
+        mock_handler = MagicMock()
+        mock_handler.name = "test_tool"
+        
+        # Register handler
+        server.add_tool_handler(mock_handler)
+        
+        # Check registration
+        assert "test_tool" in server.tool_handlers
+        assert server.get_tool_handler("test_tool") == mock_handler
+        assert server.get_tool_handler("nonexistent") is None
+        
+        # Restore original handlers
+        server.tool_handlers = original_handlers
+        
+    @pytest.mark.asyncio
+    async def test_list_tools(self):
+        """Test listing available tools."""
+        # Create mock handlers
+        mock_handler1 = MagicMock()
+        mock_handler1.get_tool_description.return_value = Tool(
+            name="tool1",
+            description="Tool 1 description",
+            inputSchema={"type": "object"}
+        )
+        
+        mock_handler2 = MagicMock()
+        mock_handler2.get_tool_description.return_value = Tool(
+            name="tool2",
+            description="Tool 2 description",
+            inputSchema={"type": "object"}
+        )
+        
+        # Temporarily replace handlers
+        original_handlers = server.tool_handlers.copy()
+        server.tool_handlers = {
+            "tool1": mock_handler1,
+            "tool2": mock_handler2
+        }
+        
+        # Test list_tools
+        tools = await server.list_tools()
+        
+        assert len(tools) == 2
+        assert any(t.name == "tool1" for t in tools)
+        assert any(t.name == "tool2" for t in tools)
+        
+        # Restore original handlers
+        server.tool_handlers = original_handlers
+        
+    @pytest.mark.asyncio
+    async def test_call_tool_success(self):
+        """Test successful tool call."""
+        # Create mock handler
+        mock_handler = MagicMock()
+        mock_handler.run_tool.return_value = [
+            MagicMock(type="text", text="Success")
+        ]
+        
+        # Temporarily replace handlers
+        original_handlers = server.tool_handlers.copy()
+        server.tool_handlers = {"test_tool": mock_handler}
+        
+        # Test call_tool
+        result = await server.call_tool("test_tool", {"arg1": "value1"})
+        
+        mock_handler.run_tool.assert_called_once_with({"arg1": "value1"})
+        assert len(result) == 1
+        assert result[0].text == "Success"
+        
+        # Restore original handlers
+        server.tool_handlers = original_handlers
+        
+    @pytest.mark.asyncio
+    async def test_call_tool_invalid_arguments(self):
+        """Test tool call with invalid arguments."""
+        with pytest.raises(RuntimeError) as exc_info:
+            await server.call_tool("any_tool", "not_a_dict")
+        assert "arguments must be dictionary" in str(exc_info.value)
+        
+    @pytest.mark.asyncio
+    async def test_call_tool_unknown_tool(self):
+        """Test calling an unknown tool."""
+        with pytest.raises(ValueError) as exc_info:
+            await server.call_tool("unknown_tool", {})
+        assert "Unknown tool: unknown_tool" in str(exc_info.value)
+        
+    @pytest.mark.asyncio
+    async def test_call_tool_handler_exception(self):
+        """Test tool handler raising an exception."""
+        # Create mock handler that raises exception
+        mock_handler = MagicMock()
+        mock_handler.run_tool.side_effect = Exception("Handler error")
+        
+        # Temporarily replace handlers
+        original_handlers = server.tool_handlers.copy()
+        server.tool_handlers = {"failing_tool": mock_handler}
+        
+        # Test call_tool
+        with pytest.raises(RuntimeError) as exc_info:
+            await server.call_tool("failing_tool", {})
+        assert "Handler error" in str(exc_info.value)
+        
+        # Restore original handlers
+        server.tool_handlers = original_handlers
+        
+    def test_all_tools_registered(self):
+        """Test that all expected tools are registered."""
+        expected_tools = [
+            "obsidian_list_files_in_vault",
+            "obsidian_list_files_in_dir",
+            "obsidian_get_file_contents",
+            "obsidian_search",
+            "obsidian_patch_content",
+            "obsidian_append_content",
+            "obsidian_put_content",
+            "obsidian_delete_file",
+            "obsidian_complex_search",
+            "obsidian_batch_get_file_contents",
+            "obsidian_periodic_notes",
+            "obsidian_recent_periodic_notes",
+            "obsidian_recent_changes"
+        ]
+        
+        for tool_name in expected_tools:
+            assert tool_name in server.tool_handlers, f"Tool {tool_name} not registered"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,31 +2,39 @@
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from mcp_obsidian import server
+from mcp_obsidian.config import Settings
 from mcp.types import Tool
 
 class TestServer:
     """Test the MCP server functionality."""
     
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Initialize tool handlers before each test."""
+        # Create a test config
+        test_config = Settings(obsidian_api_key="test_key")
+        # Initialize handlers for testing
+        server.initialize_tool_handlers(test_config)
+        yield
+        # Clean up after test
+        server.tool_handlers.clear()
+    
     def test_tool_handler_registration(self):
-        """Test that tool handlers are registered correctly."""
+        """Test that tool handlers can be registered and retrieved."""
         # Clear existing handlers for test
-        original_handlers = server.tool_handlers.copy()
         server.tool_handlers.clear()
         
         # Create mock handler
         mock_handler = MagicMock()
         mock_handler.name = "test_tool"
         
-        # Register handler
-        server.add_tool_handler(mock_handler)
+        # Register handler directly
+        server.tool_handlers["test_tool"] = mock_handler
         
         # Check registration
         assert "test_tool" in server.tool_handlers
         assert server.get_tool_handler("test_tool") == mock_handler
         assert server.get_tool_handler("nonexistent") is None
-        
-        # Restore original handlers
-        server.tool_handlers = original_handlers
         
     @pytest.mark.asyncio
     async def test_list_tools(self):
@@ -120,21 +128,25 @@ class TestServer:
         server.tool_handlers = original_handlers
         
     def test_all_tools_registered(self):
-        """Test that all expected tools are registered."""
+        """Test that all expected tools are registered after initialization."""
+        # Re-initialize with test config to ensure all tools are registered
+        test_config = Settings(obsidian_api_key="test_key")
+        server.initialize_tool_handlers(test_config)
+        
         expected_tools = [
             "obsidian_list_files_in_vault",
             "obsidian_list_files_in_dir",
             "obsidian_get_file_contents",
-            "obsidian_search",
+            "obsidian_simple_search",
             "obsidian_patch_content",
             "obsidian_append_content",
             "obsidian_put_content",
             "obsidian_delete_file",
             "obsidian_complex_search",
             "obsidian_batch_get_file_contents",
-            "obsidian_periodic_notes",
-            "obsidian_recent_periodic_notes",
-            "obsidian_recent_changes"
+            "obsidian_get_periodic_note",
+            "obsidian_get_recent_periodic_notes",
+            "obsidian_get_recent_changes"
         ]
         
         for tool_name in expected_tools:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,6 +2,7 @@
 import pytest
 import json
 from unittest.mock import MagicMock, patch
+from mcp_obsidian.config import Settings
 from mcp_obsidian.tools import (
     ListFilesInVaultToolHandler,
     ListFilesInDirToolHandler,
@@ -11,12 +12,15 @@ from mcp_obsidian.tools import (
     DeleteFileToolHandler
 )
 
+# Create a test config for all tool handlers
+test_config = Settings(obsidian_api_key="test-api-key")
+
 class TestListFilesInVaultToolHandler:
     """Test the ListFilesInVaultToolHandler."""
     
     def test_tool_description(self):
         """Test tool description."""
-        handler = ListFilesInVaultToolHandler()
+        handler = ListFilesInVaultToolHandler(test_config)
         tool = handler.get_tool_description()
         
         assert tool.name == "obsidian_list_files_in_vault"
@@ -33,7 +37,7 @@ class TestListFilesInVaultToolHandler:
             {"path": "folder1", "type": "directory"}
         ]
         
-        handler = ListFilesInVaultToolHandler()
+        handler = ListFilesInVaultToolHandler(test_config)
         result = handler.run_tool({})
         
         assert len(result) == 1
@@ -47,7 +51,7 @@ class TestListFilesInDirToolHandler:
     
     def test_tool_description(self):
         """Test tool description."""
-        handler = ListFilesInDirToolHandler()
+        handler = ListFilesInDirToolHandler(test_config)
         tool = handler.get_tool_description()
         
         assert tool.name == "obsidian_list_files_in_dir"
@@ -56,7 +60,7 @@ class TestListFilesInDirToolHandler:
         
     def test_run_tool_missing_dirpath(self):
         """Test running tool without required dirpath."""
-        handler = ListFilesInDirToolHandler()
+        handler = ListFilesInDirToolHandler(test_config)
         
         with pytest.raises(RuntimeError) as exc_info:
             handler.run_tool({})
@@ -71,7 +75,7 @@ class TestListFilesInDirToolHandler:
             {"path": "subfolder/file2.md", "type": "file"}
         ]
         
-        handler = ListFilesInDirToolHandler()
+        handler = ListFilesInDirToolHandler(test_config)
         result = handler.run_tool({"dirpath": "subfolder"})
         
         mock_client.list_files_in_dir.assert_called_once_with("subfolder")
@@ -84,7 +88,7 @@ class TestGetFileContentsToolHandler:
     
     def test_tool_description(self):
         """Test tool description."""
-        handler = GetFileContentsToolHandler()
+        handler = GetFileContentsToolHandler(test_config)
         tool = handler.get_tool_description()
         
         assert tool.name == "obsidian_get_file_contents"
@@ -92,7 +96,7 @@ class TestGetFileContentsToolHandler:
         
     def test_run_tool_missing_filepath(self):
         """Test running tool without required filepath."""
-        handler = GetFileContentsToolHandler()
+        handler = GetFileContentsToolHandler(test_config)
         
         with pytest.raises(RuntimeError) as exc_info:
             handler.run_tool({})
@@ -105,7 +109,7 @@ class TestGetFileContentsToolHandler:
         mock_obsidian_class.return_value = mock_client
         mock_client.get_file_contents.return_value = "# Test Content\n\nThis is a test."
         
-        handler = GetFileContentsToolHandler()
+        handler = GetFileContentsToolHandler(test_config)
         result = handler.run_tool({"filepath": "test.md"})
         
         mock_client.get_file_contents.assert_called_once_with("test.md")
@@ -117,16 +121,16 @@ class TestSearchToolHandler:
     
     def test_tool_description(self):
         """Test tool description."""
-        handler = SearchToolHandler()
+        handler = SearchToolHandler(test_config)
         tool = handler.get_tool_description()
         
-        assert tool.name == "obsidian_search"
-        assert "search" in tool.description.lower()
+        assert tool.name == "obsidian_simple_search"
+        assert "simple search" in tool.description.lower()
         assert "query" in tool.inputSchema["required"]
         
     def test_run_tool_missing_query(self):
         """Test running tool without required query."""
-        handler = SearchToolHandler()
+        handler = SearchToolHandler(test_config)
         
         with pytest.raises(RuntimeError) as exc_info:
             handler.run_tool({})
@@ -144,10 +148,10 @@ class TestSearchToolHandler:
             }
         ]
         
-        handler = SearchToolHandler()
+        handler = SearchToolHandler(test_config)
         result = handler.run_tool({"query": "test query"})
         
-        mock_client.search.assert_called_once_with("test query")
+        mock_client.search.assert_called_once_with("test query", 100)
         assert len(result) == 1
         data = json.loads(result[0].text)
         assert data[0]["filename"] == "note1.md"
@@ -157,7 +161,7 @@ class TestAppendContentToolHandler:
     
     def test_tool_description(self):
         """Test tool description."""
-        handler = AppendContentToolHandler()
+        handler = AppendContentToolHandler(test_config)
         tool = handler.get_tool_description()
         
         assert tool.name == "obsidian_append_content"
@@ -167,15 +171,15 @@ class TestAppendContentToolHandler:
         
     def test_run_tool_missing_args(self):
         """Test running tool without required arguments."""
-        handler = AppendContentToolHandler()
+        handler = AppendContentToolHandler(test_config)
         
         with pytest.raises(RuntimeError) as exc_info:
             handler.run_tool({})
-        assert "filepath argument missing" in str(exc_info.value)
+        assert "filepath and content arguments required" in str(exc_info.value)
         
         with pytest.raises(RuntimeError) as exc_info:
             handler.run_tool({"filepath": "test.md"})
-        assert "content argument missing" in str(exc_info.value)
+        assert "filepath and content arguments required" in str(exc_info.value)
         
     @patch('mcp_obsidian.tools.obsidian.Obsidian')
     def test_run_tool_with_args(self, mock_obsidian_class):
@@ -184,7 +188,7 @@ class TestAppendContentToolHandler:
         mock_obsidian_class.return_value = mock_client
         mock_client.append_content.return_value = {"message": "Content appended"}
         
-        handler = AppendContentToolHandler()
+        handler = AppendContentToolHandler(test_config)
         result = handler.run_tool({
             "filepath": "test.md",
             "content": "New content to append"
@@ -195,15 +199,14 @@ class TestAppendContentToolHandler:
             "New content to append"
         )
         assert len(result) == 1
-        data = json.loads(result[0].text)
-        assert data["message"] == "Content appended"
+        assert result[0].text == "Successfully appended content to test.md"
 
 class TestDeleteFileToolHandler:
     """Test the DeleteFileToolHandler."""
     
     def test_tool_description(self):
         """Test tool description."""
-        handler = DeleteFileToolHandler()
+        handler = DeleteFileToolHandler(test_config)
         tool = handler.get_tool_description()
         
         assert tool.name == "obsidian_delete_file"
@@ -217,10 +220,10 @@ class TestDeleteFileToolHandler:
         mock_obsidian_class.return_value = mock_client
         mock_client.delete_file.return_value = {"message": "File deleted"}
         
-        handler = DeleteFileToolHandler()
-        result = handler.run_tool({"filepath": "test.md"})
+        handler = DeleteFileToolHandler(test_config)
+        result = handler.run_tool({"filepath": "test.md", "confirm": True})
         
         mock_client.delete_file.assert_called_once_with("test.md")
         assert len(result) == 1
-        data = json.loads(result[0].text)
-        assert data["message"] == "File deleted"
+        assert "Successfully deleted" in result[0].text
+        assert "test.md" in result[0].text

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,226 @@
+"""Tests for tool handlers."""
+import pytest
+import json
+from unittest.mock import MagicMock, patch
+from mcp_obsidian.tools import (
+    ListFilesInVaultToolHandler,
+    ListFilesInDirToolHandler,
+    GetFileContentsToolHandler,
+    SearchToolHandler,
+    AppendContentToolHandler,
+    DeleteFileToolHandler
+)
+
+class TestListFilesInVaultToolHandler:
+    """Test the ListFilesInVaultToolHandler."""
+    
+    def test_tool_description(self):
+        """Test tool description."""
+        handler = ListFilesInVaultToolHandler()
+        tool = handler.get_tool_description()
+        
+        assert tool.name == "obsidian_list_files_in_vault"
+        assert "vault" in tool.description.lower()
+        assert tool.inputSchema["required"] == []
+        
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_run_tool(self, mock_obsidian_class):
+        """Test running the list files in vault tool."""
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.list_files_in_vault.return_value = [
+            {"path": "file1.md", "type": "file"},
+            {"path": "folder1", "type": "directory"}
+        ]
+        
+        handler = ListFilesInVaultToolHandler()
+        result = handler.run_tool({})
+        
+        assert len(result) == 1
+        assert result[0].type == "text"
+        data = json.loads(result[0].text)
+        assert len(data) == 2
+        assert data[0]["path"] == "file1.md"
+
+class TestListFilesInDirToolHandler:
+    """Test the ListFilesInDirToolHandler."""
+    
+    def test_tool_description(self):
+        """Test tool description."""
+        handler = ListFilesInDirToolHandler()
+        tool = handler.get_tool_description()
+        
+        assert tool.name == "obsidian_list_files_in_dir"
+        assert "directory" in tool.description.lower()
+        assert "dirpath" in tool.inputSchema["required"]
+        
+    def test_run_tool_missing_dirpath(self):
+        """Test running tool without required dirpath."""
+        handler = ListFilesInDirToolHandler()
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            handler.run_tool({})
+        assert "dirpath argument missing" in str(exc_info.value)
+        
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_run_tool_with_dirpath(self, mock_obsidian_class):
+        """Test running the list files in dir tool."""
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.list_files_in_dir.return_value = [
+            {"path": "subfolder/file2.md", "type": "file"}
+        ]
+        
+        handler = ListFilesInDirToolHandler()
+        result = handler.run_tool({"dirpath": "subfolder"})
+        
+        mock_client.list_files_in_dir.assert_called_once_with("subfolder")
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert data[0]["path"] == "subfolder/file2.md"
+
+class TestGetFileContentsToolHandler:
+    """Test the GetFileContentsToolHandler."""
+    
+    def test_tool_description(self):
+        """Test tool description."""
+        handler = GetFileContentsToolHandler()
+        tool = handler.get_tool_description()
+        
+        assert tool.name == "obsidian_get_file_contents"
+        assert "filepath" in tool.inputSchema["required"]
+        
+    def test_run_tool_missing_filepath(self):
+        """Test running tool without required filepath."""
+        handler = GetFileContentsToolHandler()
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            handler.run_tool({})
+        assert "filepath argument missing" in str(exc_info.value)
+        
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_run_tool_with_filepath(self, mock_obsidian_class):
+        """Test getting file contents."""
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.get_file_contents.return_value = "# Test Content\n\nThis is a test."
+        
+        handler = GetFileContentsToolHandler()
+        result = handler.run_tool({"filepath": "test.md"})
+        
+        mock_client.get_file_contents.assert_called_once_with("test.md")
+        assert len(result) == 1
+        assert result[0].text == "# Test Content\n\nThis is a test."
+
+class TestSearchToolHandler:
+    """Test the SearchToolHandler."""
+    
+    def test_tool_description(self):
+        """Test tool description."""
+        handler = SearchToolHandler()
+        tool = handler.get_tool_description()
+        
+        assert tool.name == "obsidian_search"
+        assert "search" in tool.description.lower()
+        assert "query" in tool.inputSchema["required"]
+        
+    def test_run_tool_missing_query(self):
+        """Test running tool without required query."""
+        handler = SearchToolHandler()
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            handler.run_tool({})
+        assert "query argument missing" in str(exc_info.value)
+        
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_run_tool_with_query(self, mock_obsidian_class):
+        """Test searching with query."""
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.search.return_value = [
+            {
+                "filename": "note1.md",
+                "matches": [{"match": {"text": "found text"}, "line": 5}]
+            }
+        ]
+        
+        handler = SearchToolHandler()
+        result = handler.run_tool({"query": "test query"})
+        
+        mock_client.search.assert_called_once_with("test query")
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert data[0]["filename"] == "note1.md"
+
+class TestAppendContentToolHandler:
+    """Test the AppendContentToolHandler."""
+    
+    def test_tool_description(self):
+        """Test tool description."""
+        handler = AppendContentToolHandler()
+        tool = handler.get_tool_description()
+        
+        assert tool.name == "obsidian_append_content"
+        assert "append" in tool.description.lower()
+        assert "filepath" in tool.inputSchema["required"]
+        assert "content" in tool.inputSchema["required"]
+        
+    def test_run_tool_missing_args(self):
+        """Test running tool without required arguments."""
+        handler = AppendContentToolHandler()
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            handler.run_tool({})
+        assert "filepath argument missing" in str(exc_info.value)
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            handler.run_tool({"filepath": "test.md"})
+        assert "content argument missing" in str(exc_info.value)
+        
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_run_tool_with_args(self, mock_obsidian_class):
+        """Test appending content."""
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.append_content.return_value = {"message": "Content appended"}
+        
+        handler = AppendContentToolHandler()
+        result = handler.run_tool({
+            "filepath": "test.md",
+            "content": "New content to append"
+        })
+        
+        mock_client.append_content.assert_called_once_with(
+            "test.md", 
+            "New content to append"
+        )
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert data["message"] == "Content appended"
+
+class TestDeleteFileToolHandler:
+    """Test the DeleteFileToolHandler."""
+    
+    def test_tool_description(self):
+        """Test tool description."""
+        handler = DeleteFileToolHandler()
+        tool = handler.get_tool_description()
+        
+        assert tool.name == "obsidian_delete_file"
+        assert "delete" in tool.description.lower()
+        assert "filepath" in tool.inputSchema["required"]
+        
+    @patch('mcp_obsidian.tools.obsidian.Obsidian')
+    def test_run_tool_with_filepath(self, mock_obsidian_class):
+        """Test deleting a file."""
+        mock_client = MagicMock()
+        mock_obsidian_class.return_value = mock_client
+        mock_client.delete_file.return_value = {"message": "File deleted"}
+        
+        handler = DeleteFileToolHandler()
+        result = handler.run_tool({"filepath": "test.md"})
+        
+        mock_client.delete_file.assert_called_once_with("test.md")
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert data["message"] == "File deleted"

--- a/uv.lock
+++ b/uv.lock
@@ -275,6 +275,7 @@ version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
+    { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "requests" },
 ]
@@ -292,6 +293,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=1.1.0" },
+    { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "requests", specifier = ">=2.32.3" },
 ]
@@ -398,6 +400,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/d8/c080592d80edd3441ab7f88f865f51dae94a157fc64283c680e9f32cf6da/pydantic_core-2.27.1-cp313-none-win32.whl", hash = "sha256:8065914ff79f7eab1599bd80406681f0ad08f8e47c880f17b416c9f8f7a26d05", size = 1833713, upload-time = "2024-11-22T00:23:01.715Z" },
     { url = "https://files.pythonhosted.org/packages/83/84/5ab82a9ee2538ac95a66e51f6838d6aba6e0a03a42aa185ad2fe404a4e8f/pydantic_core-2.27.1-cp313-none-win_amd64.whl", hash = "sha256:ba630d5e3db74c79300d9a5bdaaf6200172b107f263c98a0539eeecb857b2337", size = 1987897, upload-time = "2024-11-22T00:23:03.497Z" },
     { url = "https://files.pythonhosted.org/packages/df/c3/b15fb833926d91d982fde29c0624c9f225da743c7af801dace0d4e187e71/pydantic_core-2.27.1-cp313-none-win_arm64.whl", hash = "sha256:45cf8588c066860b623cd11c4ba687f8d7175d5f7ef65f7129df8a394c502de5", size = 1882983, upload-time = "2024-11-22T00:23:05.983Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
 ]
 
 [[package]]
@@ -630,6 +646,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -276,8 +288,8 @@ source = { editable = "." }
 dependencies = [
     { name = "mcp" },
     { name = "pydantic-settings" },
-    { name = "python-dotenv" },
     { name = "requests" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -294,8 +306,8 @@ dev = [
 requires-dist = [
     { name = "mcp", specifier = ">=1.1.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "requests", specifier = ">=2.32.3" },
+    { name = "typer", specifier = ">=0.9.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -306,6 +318,15 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "responses", specifier = ">=0.24.0" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -566,6 +587,28 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -637,6 +680,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.17.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/82/f4bfed3bc18c6ebd6f828320811bbe4098f92a31adf4040bee59c4ae02ea/typer-0.17.3.tar.gz", hash = "sha256:0c600503d472bcf98d29914d4dcd67f80c24cc245395e2e00ba3603c9332e8ba", size = 103517, upload-time = "2025-08-30T12:35:24.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/e8/b3d537470e8404659a6335e7af868e90657efb73916ef31ddf3d8b9cb237/typer-0.17.3-py3-none-any.whl", hash = "sha256:643919a79182ab7ac7581056d93c6a2b865b026adf2872c4d02c72758e6f095b", size = 46494, upload-time = "2025-08-30T12:35:22.391Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,14 @@
 version = 1
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -18,72 +19,72 @@ dependencies = [
     { name = "idna" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/09/45b9b7a6d4e45c6bcb5bf61d19e3ab87df68e0601fa8c5293de3542546cc/anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c", size = 173422 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/09/45b9b7a6d4e45c6bcb5bf61d19e3ab87df68e0601fa8c5293de3542546cc/anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c", size = 173422, upload-time = "2024-10-14T14:31:44.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d", size = 90377 },
+    { url = "https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d", size = 90377, upload-time = "2024-10-14T14:31:42.623Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2024.8.30"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507, upload-time = "2024-08-30T01:55:04.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321 },
+    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321, upload-time = "2024-08-30T01:55:02.591Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz", hash = "sha256:223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e", size = 106620 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz", hash = "sha256:223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e", size = 106620, upload-time = "2024-10-09T07:40:20.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c", size = 193339 },
-    { url = "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944", size = 124366 },
-    { url = "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee", size = 118874 },
-    { url = "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c", size = 138243 },
-    { url = "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6", size = 148676 },
-    { url = "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea", size = 141289 },
-    { url = "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc", size = 142585 },
-    { url = "https://files.pythonhosted.org/packages/3b/a0/a68980ab8a1f45a36d9745d35049c1af57d27255eff8c907e3add84cf68f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82357d85de703176b5587dbe6ade8ff67f9f69a41c0733cf2425378b49954de5", size = 144408 },
-    { url = "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594", size = 139076 },
-    { url = "https://files.pythonhosted.org/packages/fb/9d/9c13753a5a6e0db4a0a6edb1cef7aee39859177b64e1a1e748a6e3ba62c2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8ce7fd6767a1cc5a92a639b391891bf1c268b03ec7e021c7d6d902285259685c", size = 146874 },
-    { url = "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365", size = 150871 },
-    { url = "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129", size = 148546 },
-    { url = "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236", size = 143048 },
-    { url = "https://files.pythonhosted.org/packages/01/f8/38842422988b795220eb8038745d27a675ce066e2ada79516c118f291f07/charset_normalizer-3.4.0-cp311-cp311-win32.whl", hash = "sha256:9ae4ef0b3f6b41bad6366fb0ea4fc1d7ed051528e113a60fa2a65a9abb5b1d99", size = 94389 },
-    { url = "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27", size = 101752 },
-    { url = "https://files.pythonhosted.org/packages/d3/0b/4b7a70987abf9b8196845806198975b6aab4ce016632f817ad758a5aa056/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6", size = 194445 },
-    { url = "https://files.pythonhosted.org/packages/50/89/354cc56cf4dd2449715bc9a0f54f3aef3dc700d2d62d1fa5bbea53b13426/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf", size = 125275 },
-    { url = "https://files.pythonhosted.org/packages/fa/44/b730e2a2580110ced837ac083d8ad222343c96bb6b66e9e4e706e4d0b6df/charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a51b48f42d9358460b78725283f04bddaf44a9358197b889657deba38f329db", size = 119020 },
-    { url = "https://files.pythonhosted.org/packages/9d/e4/9263b8240ed9472a2ae7ddc3e516e71ef46617fe40eaa51221ccd4ad9a27/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b295729485b06c1a0683af02a9e42d2caa9db04a373dc38a6a58cdd1e8abddf1", size = 139128 },
-    { url = "https://files.pythonhosted.org/packages/6b/e3/9f73e779315a54334240353eaea75854a9a690f3f580e4bd85d977cb2204/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee803480535c44e7f5ad00788526da7d85525cfefaf8acf8ab9a310000be4b03", size = 149277 },
-    { url = "https://files.pythonhosted.org/packages/1a/cf/f1f50c2f295312edb8a548d3fa56a5c923b146cd3f24114d5adb7e7be558/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d59d125ffbd6d552765510e3f31ed75ebac2c7470c7274195b9161a32350284", size = 142174 },
-    { url = "https://files.pythonhosted.org/packages/16/92/92a76dc2ff3a12e69ba94e7e05168d37d0345fa08c87e1fe24d0c2a42223/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15", size = 143838 },
-    { url = "https://files.pythonhosted.org/packages/a4/01/2117ff2b1dfc61695daf2babe4a874bca328489afa85952440b59819e9d7/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07afec21bbbbf8a5cc3651aa96b980afe2526e7f048fdfb7f1014d84acc8b6d8", size = 146149 },
-    { url = "https://files.pythonhosted.org/packages/f6/9b/93a332b8d25b347f6839ca0a61b7f0287b0930216994e8bf67a75d050255/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6b40e8d38afe634559e398cc32b1472f376a4099c75fe6299ae607e404c033b2", size = 140043 },
-    { url = "https://files.pythonhosted.org/packages/ab/f6/7ac4a01adcdecbc7a7587767c776d53d369b8b971382b91211489535acf0/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b8dcd239c743aa2f9c22ce674a145e0a25cb1566c495928440a181ca1ccf6719", size = 148229 },
-    { url = "https://files.pythonhosted.org/packages/9d/be/5708ad18161dee7dc6a0f7e6cf3a88ea6279c3e8484844c0590e50e803ef/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:84450ba661fb96e9fd67629b93d2941c871ca86fc38d835d19d4225ff946a631", size = 151556 },
-    { url = "https://files.pythonhosted.org/packages/5a/bb/3d8bc22bacb9eb89785e83e6723f9888265f3a0de3b9ce724d66bd49884e/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:44aeb140295a2f0659e113b31cfe92c9061622cadbc9e2a2f7b8ef6b1e29ef4b", size = 149772 },
-    { url = "https://files.pythonhosted.org/packages/f7/fa/d3fc622de05a86f30beea5fc4e9ac46aead4731e73fd9055496732bcc0a4/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1db4e7fefefd0f548d73e2e2e041f9df5c59e178b4c72fbac4cc6f535cfb1565", size = 144800 },
-    { url = "https://files.pythonhosted.org/packages/9a/65/bdb9bc496d7d190d725e96816e20e2ae3a6fa42a5cac99c3c3d6ff884118/charset_normalizer-3.4.0-cp312-cp312-win32.whl", hash = "sha256:5726cf76c982532c1863fb64d8c6dd0e4c90b6ece9feb06c9f202417a31f7dd7", size = 94836 },
-    { url = "https://files.pythonhosted.org/packages/3e/67/7b72b69d25b89c0b3cea583ee372c43aa24df15f0e0f8d3982c57804984b/charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:b197e7094f232959f8f20541ead1d9862ac5ebea1d58e9849c1bf979255dfac9", size = 102187 },
-    { url = "https://files.pythonhosted.org/packages/f3/89/68a4c86f1a0002810a27f12e9a7b22feb198c59b2f05231349fbce5c06f4/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dd4eda173a9fcccb5f2e2bd2a9f423d180194b1bf17cf59e3269899235b2a114", size = 194617 },
-    { url = "https://files.pythonhosted.org/packages/4f/cd/8947fe425e2ab0aa57aceb7807af13a0e4162cd21eee42ef5b053447edf5/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9e3c4c9e1ed40ea53acf11e2a386383c3304212c965773704e4603d589343ed", size = 125310 },
-    { url = "https://files.pythonhosted.org/packages/5b/f0/b5263e8668a4ee9becc2b451ed909e9c27058337fda5b8c49588183c267a/charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92a7e36b000bf022ef3dbb9c46bfe2d52c047d5e3f3343f43204263c5addc250", size = 119126 },
-    { url = "https://files.pythonhosted.org/packages/ff/6e/e445afe4f7fda27a533f3234b627b3e515a1b9429bc981c9a5e2aa5d97b6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54b6a92d009cbe2fb11054ba694bc9e284dad30a26757b1e372a1fdddaf21920", size = 139342 },
-    { url = "https://files.pythonhosted.org/packages/a1/b2/4af9993b532d93270538ad4926c8e37dc29f2111c36f9c629840c57cd9b3/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ffd9493de4c922f2a38c2bf62b831dcec90ac673ed1ca182fe11b4d8e9f2a64", size = 149383 },
-    { url = "https://files.pythonhosted.org/packages/fb/6f/4e78c3b97686b871db9be6f31d64e9264e889f8c9d7ab33c771f847f79b7/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c404d74c2926d0287fbd63ed5d27eb911eb9e4a3bb2c6d294f3cfd4a9e0c23", size = 142214 },
-    { url = "https://files.pythonhosted.org/packages/2b/c9/1c8fe3ce05d30c87eff498592c89015b19fade13df42850aafae09e94f35/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4796efc4faf6b53a18e3d46343535caed491776a22af773f366534056c4e1fbc", size = 144104 },
-    { url = "https://files.pythonhosted.org/packages/ee/68/efad5dcb306bf37db7db338338e7bb8ebd8cf38ee5bbd5ceaaaa46f257e6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7fdd52961feb4c96507aa649550ec2a0d527c086d284749b2f582f2d40a2e0d", size = 146255 },
-    { url = "https://files.pythonhosted.org/packages/0c/75/1ed813c3ffd200b1f3e71121c95da3f79e6d2a96120163443b3ad1057505/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:92db3c28b5b2a273346bebb24857fda45601aef6ae1c011c0a997106581e8a88", size = 140251 },
-    { url = "https://files.pythonhosted.org/packages/7d/0d/6f32255c1979653b448d3c709583557a4d24ff97ac4f3a5be156b2e6a210/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ab973df98fc99ab39080bfb0eb3a925181454d7c3ac8a1e695fddfae696d9e90", size = 148474 },
-    { url = "https://files.pythonhosted.org/packages/ac/a0/c1b5298de4670d997101fef95b97ac440e8c8d8b4efa5a4d1ef44af82f0d/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b67fdab07fdd3c10bb21edab3cbfe8cf5696f453afce75d815d9d7223fbe88b", size = 151849 },
-    { url = "https://files.pythonhosted.org/packages/04/4f/b3961ba0c664989ba63e30595a3ed0875d6790ff26671e2aae2fdc28a399/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aa41e526a5d4a9dfcfbab0716c7e8a1b215abd3f3df5a45cf18a12721d31cb5d", size = 149781 },
-    { url = "https://files.pythonhosted.org/packages/d8/90/6af4cd042066a4adad58ae25648a12c09c879efa4849c705719ba1b23d8c/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482", size = 144970 },
-    { url = "https://files.pythonhosted.org/packages/cc/67/e5e7e0cbfefc4ca79025238b43cdf8a2037854195b37d6417f3d0895c4c2/charset_normalizer-3.4.0-cp313-cp313-win32.whl", hash = "sha256:f19c1585933c82098c2a520f8ec1227f20e339e33aca8fa6f956f6691b784e67", size = 94973 },
-    { url = "https://files.pythonhosted.org/packages/65/97/fc9bbc54ee13d33dc54a7fcf17b26368b18505500fc01e228c27b5222d80/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:707b82d19e65c9bd28b81dde95249b07bf9f5b90ebe1ef17d9b57473f8a64b7b", size = 102308 },
-    { url = "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl", hash = "sha256:fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079", size = 49446 },
+    { url = "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c", size = 193339, upload-time = "2024-10-09T07:38:24.527Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944", size = 124366, upload-time = "2024-10-09T07:38:26.488Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee", size = 118874, upload-time = "2024-10-09T07:38:28.115Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c", size = 138243, upload-time = "2024-10-09T07:38:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6", size = 148676, upload-time = "2024-10-09T07:38:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea", size = 141289, upload-time = "2024-10-09T07:38:32.557Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc", size = 142585, upload-time = "2024-10-09T07:38:33.649Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/a0/a68980ab8a1f45a36d9745d35049c1af57d27255eff8c907e3add84cf68f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82357d85de703176b5587dbe6ade8ff67f9f69a41c0733cf2425378b49954de5", size = 144408, upload-time = "2024-10-09T07:38:34.687Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594", size = 139076, upload-time = "2024-10-09T07:38:36.417Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/9d/9c13753a5a6e0db4a0a6edb1cef7aee39859177b64e1a1e748a6e3ba62c2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8ce7fd6767a1cc5a92a639b391891bf1c268b03ec7e021c7d6d902285259685c", size = 146874, upload-time = "2024-10-09T07:38:37.59Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365", size = 150871, upload-time = "2024-10-09T07:38:38.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129", size = 148546, upload-time = "2024-10-09T07:38:40.459Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236", size = 143048, upload-time = "2024-10-09T07:38:42.178Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f8/38842422988b795220eb8038745d27a675ce066e2ada79516c118f291f07/charset_normalizer-3.4.0-cp311-cp311-win32.whl", hash = "sha256:9ae4ef0b3f6b41bad6366fb0ea4fc1d7ed051528e113a60fa2a65a9abb5b1d99", size = 94389, upload-time = "2024-10-09T07:38:43.339Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27", size = 101752, upload-time = "2024-10-09T07:38:44.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4b7a70987abf9b8196845806198975b6aab4ce016632f817ad758a5aa056/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6", size = 194445, upload-time = "2024-10-09T07:38:45.275Z" },
+    { url = "https://files.pythonhosted.org/packages/50/89/354cc56cf4dd2449715bc9a0f54f3aef3dc700d2d62d1fa5bbea53b13426/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf", size = 125275, upload-time = "2024-10-09T07:38:46.449Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/44/b730e2a2580110ced837ac083d8ad222343c96bb6b66e9e4e706e4d0b6df/charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a51b48f42d9358460b78725283f04bddaf44a9358197b889657deba38f329db", size = 119020, upload-time = "2024-10-09T07:38:48.88Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e4/9263b8240ed9472a2ae7ddc3e516e71ef46617fe40eaa51221ccd4ad9a27/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b295729485b06c1a0683af02a9e42d2caa9db04a373dc38a6a58cdd1e8abddf1", size = 139128, upload-time = "2024-10-09T07:38:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e3/9f73e779315a54334240353eaea75854a9a690f3f580e4bd85d977cb2204/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee803480535c44e7f5ad00788526da7d85525cfefaf8acf8ab9a310000be4b03", size = 149277, upload-time = "2024-10-09T07:38:52.306Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/cf/f1f50c2f295312edb8a548d3fa56a5c923b146cd3f24114d5adb7e7be558/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d59d125ffbd6d552765510e3f31ed75ebac2c7470c7274195b9161a32350284", size = 142174, upload-time = "2024-10-09T07:38:53.458Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/92a76dc2ff3a12e69ba94e7e05168d37d0345fa08c87e1fe24d0c2a42223/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15", size = 143838, upload-time = "2024-10-09T07:38:54.691Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/01/2117ff2b1dfc61695daf2babe4a874bca328489afa85952440b59819e9d7/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07afec21bbbbf8a5cc3651aa96b980afe2526e7f048fdfb7f1014d84acc8b6d8", size = 146149, upload-time = "2024-10-09T07:38:55.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/9b/93a332b8d25b347f6839ca0a61b7f0287b0930216994e8bf67a75d050255/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6b40e8d38afe634559e398cc32b1472f376a4099c75fe6299ae607e404c033b2", size = 140043, upload-time = "2024-10-09T07:38:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f6/7ac4a01adcdecbc7a7587767c776d53d369b8b971382b91211489535acf0/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b8dcd239c743aa2f9c22ce674a145e0a25cb1566c495928440a181ca1ccf6719", size = 148229, upload-time = "2024-10-09T07:38:58.782Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/be/5708ad18161dee7dc6a0f7e6cf3a88ea6279c3e8484844c0590e50e803ef/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:84450ba661fb96e9fd67629b93d2941c871ca86fc38d835d19d4225ff946a631", size = 151556, upload-time = "2024-10-09T07:39:00.467Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bb/3d8bc22bacb9eb89785e83e6723f9888265f3a0de3b9ce724d66bd49884e/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:44aeb140295a2f0659e113b31cfe92c9061622cadbc9e2a2f7b8ef6b1e29ef4b", size = 149772, upload-time = "2024-10-09T07:39:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/fa/d3fc622de05a86f30beea5fc4e9ac46aead4731e73fd9055496732bcc0a4/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1db4e7fefefd0f548d73e2e2e041f9df5c59e178b4c72fbac4cc6f535cfb1565", size = 144800, upload-time = "2024-10-09T07:39:02.491Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/65/bdb9bc496d7d190d725e96816e20e2ae3a6fa42a5cac99c3c3d6ff884118/charset_normalizer-3.4.0-cp312-cp312-win32.whl", hash = "sha256:5726cf76c982532c1863fb64d8c6dd0e4c90b6ece9feb06c9f202417a31f7dd7", size = 94836, upload-time = "2024-10-09T07:39:04.607Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/67/7b72b69d25b89c0b3cea583ee372c43aa24df15f0e0f8d3982c57804984b/charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:b197e7094f232959f8f20541ead1d9862ac5ebea1d58e9849c1bf979255dfac9", size = 102187, upload-time = "2024-10-09T07:39:06.247Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/89/68a4c86f1a0002810a27f12e9a7b22feb198c59b2f05231349fbce5c06f4/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dd4eda173a9fcccb5f2e2bd2a9f423d180194b1bf17cf59e3269899235b2a114", size = 194617, upload-time = "2024-10-09T07:39:07.317Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cd/8947fe425e2ab0aa57aceb7807af13a0e4162cd21eee42ef5b053447edf5/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9e3c4c9e1ed40ea53acf11e2a386383c3304212c965773704e4603d589343ed", size = 125310, upload-time = "2024-10-09T07:39:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/b5263e8668a4ee9becc2b451ed909e9c27058337fda5b8c49588183c267a/charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92a7e36b000bf022ef3dbb9c46bfe2d52c047d5e3f3343f43204263c5addc250", size = 119126, upload-time = "2024-10-09T07:39:09.327Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/e445afe4f7fda27a533f3234b627b3e515a1b9429bc981c9a5e2aa5d97b6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54b6a92d009cbe2fb11054ba694bc9e284dad30a26757b1e372a1fdddaf21920", size = 139342, upload-time = "2024-10-09T07:39:10.322Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/b2/4af9993b532d93270538ad4926c8e37dc29f2111c36f9c629840c57cd9b3/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ffd9493de4c922f2a38c2bf62b831dcec90ac673ed1ca182fe11b4d8e9f2a64", size = 149383, upload-time = "2024-10-09T07:39:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/6f/4e78c3b97686b871db9be6f31d64e9264e889f8c9d7ab33c771f847f79b7/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c404d74c2926d0287fbd63ed5d27eb911eb9e4a3bb2c6d294f3cfd4a9e0c23", size = 142214, upload-time = "2024-10-09T07:39:13.059Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c9/1c8fe3ce05d30c87eff498592c89015b19fade13df42850aafae09e94f35/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4796efc4faf6b53a18e3d46343535caed491776a22af773f366534056c4e1fbc", size = 144104, upload-time = "2024-10-09T07:39:14.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/68/efad5dcb306bf37db7db338338e7bb8ebd8cf38ee5bbd5ceaaaa46f257e6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7fdd52961feb4c96507aa649550ec2a0d527c086d284749b2f582f2d40a2e0d", size = 146255, upload-time = "2024-10-09T07:39:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/1ed813c3ffd200b1f3e71121c95da3f79e6d2a96120163443b3ad1057505/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:92db3c28b5b2a273346bebb24857fda45601aef6ae1c011c0a997106581e8a88", size = 140251, upload-time = "2024-10-09T07:39:16.995Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0d/6f32255c1979653b448d3c709583557a4d24ff97ac4f3a5be156b2e6a210/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ab973df98fc99ab39080bfb0eb3a925181454d7c3ac8a1e695fddfae696d9e90", size = 148474, upload-time = "2024-10-09T07:39:18.021Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a0/c1b5298de4670d997101fef95b97ac440e8c8d8b4efa5a4d1ef44af82f0d/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b67fdab07fdd3c10bb21edab3cbfe8cf5696f453afce75d815d9d7223fbe88b", size = 151849, upload-time = "2024-10-09T07:39:19.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4f/b3961ba0c664989ba63e30595a3ed0875d6790ff26671e2aae2fdc28a399/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aa41e526a5d4a9dfcfbab0716c7e8a1b215abd3f3df5a45cf18a12721d31cb5d", size = 149781, upload-time = "2024-10-09T07:39:20.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/6af4cd042066a4adad58ae25648a12c09c879efa4849c705719ba1b23d8c/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482", size = 144970, upload-time = "2024-10-09T07:39:21.452Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/67/e5e7e0cbfefc4ca79025238b43cdf8a2037854195b37d6417f3d0895c4c2/charset_normalizer-3.4.0-cp313-cp313-win32.whl", hash = "sha256:f19c1585933c82098c2a520f8ec1227f20e339e33aca8fa6f956f6691b784e67", size = 94973, upload-time = "2024-10-09T07:39:22.509Z" },
+    { url = "https://files.pythonhosted.org/packages/65/97/fc9bbc54ee13d33dc54a7fcf17b26368b18505500fc01e228c27b5222d80/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:707b82d19e65c9bd28b81dde95249b07bf9f5b90ebe1ef17d9b57473f8a64b7b", size = 102308, upload-time = "2024-10-09T07:39:23.524Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl", hash = "sha256:fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079", size = 49446, upload-time = "2024-10-09T07:40:19.383Z" },
 ]
 
 [[package]]
@@ -93,27 +94,107 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121, upload-time = "2023-08-17T17:29:11.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 },
+    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941, upload-time = "2023-08-17T17:29:10.08Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.10.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/70/025b179c993f019105b79575ac6edb5e084fb0f0e63f15cdebef4e454fb5/coverage-7.10.6.tar.gz", hash = "sha256:f644a3ae5933a552a29dbb9aa2f90c677a875f80ebea028e5a52a4f429044b90", size = 823736, upload-time = "2025-08-29T15:35:16.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/16/2bea27e212c4980753d6d563a0803c150edeaaddb0771a50d2afc410a261/coverage-7.10.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c706db3cabb7ceef779de68270150665e710b46d56372455cd741184f3868d8f", size = 217129, upload-time = "2025-08-29T15:33:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/51/e7159e068831ab37e31aac0969d47b8c5ee25b7d307b51e310ec34869315/coverage-7.10.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8e0c38dc289e0508ef68ec95834cb5d2e96fdbe792eaccaa1bccac3966bbadcc", size = 217532, upload-time = "2025-08-29T15:33:14.872Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c0/246ccbea53d6099325d25cd208df94ea435cd55f0db38099dd721efc7a1f/coverage-7.10.6-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:752a3005a1ded28f2f3a6e8787e24f28d6abe176ca64677bcd8d53d6fe2ec08a", size = 247931, upload-time = "2025-08-29T15:33:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fb/7435ef8ab9b2594a6e3f58505cc30e98ae8b33265d844007737946c59389/coverage-7.10.6-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:689920ecfd60f992cafca4f5477d55720466ad2c7fa29bb56ac8d44a1ac2b47a", size = 249864, upload-time = "2025-08-29T15:33:17.434Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f8/d9d64e8da7bcddb094d511154824038833c81e3a039020a9d6539bf303e9/coverage-7.10.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec98435796d2624d6905820a42f82149ee9fc4f2d45c2c5bc5a44481cc50db62", size = 251969, upload-time = "2025-08-29T15:33:18.822Z" },
+    { url = "https://files.pythonhosted.org/packages/43/28/c43ba0ef19f446d6463c751315140d8f2a521e04c3e79e5c5fe211bfa430/coverage-7.10.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b37201ce4a458c7a758ecc4efa92fa8ed783c66e0fa3c42ae19fc454a0792153", size = 249659, upload-time = "2025-08-29T15:33:20.407Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/53635bd0b72beaacf265784508a0b386defc9ab7fad99ff95f79ce9db555/coverage-7.10.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2904271c80898663c810a6b067920a61dd8d38341244a3605bd31ab55250dad5", size = 247714, upload-time = "2025-08-29T15:33:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/55/0964aa87126624e8c159e32b0bc4e84edef78c89a1a4b924d28dd8265625/coverage-7.10.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5aea98383463d6e1fa4e95416d8de66f2d0cb588774ee20ae1b28df826bcb619", size = 248351, upload-time = "2025-08-29T15:33:23.105Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ab/6cfa9dc518c6c8e14a691c54e53a9433ba67336c760607e299bfcf520cb1/coverage-7.10.6-cp311-cp311-win32.whl", hash = "sha256:e3fb1fa01d3598002777dd259c0c2e6d9d5e10e7222976fc8e03992f972a2cba", size = 219562, upload-time = "2025-08-29T15:33:24.717Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/18/99b25346690cbc55922e7cfef06d755d4abee803ef335baff0014268eff4/coverage-7.10.6-cp311-cp311-win_amd64.whl", hash = "sha256:f35ed9d945bece26553d5b4c8630453169672bea0050a564456eb88bdffd927e", size = 220453, upload-time = "2025-08-29T15:33:26.482Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ed/81d86648a07ccb124a5cf1f1a7788712b8d7216b593562683cd5c9b0d2c1/coverage-7.10.6-cp311-cp311-win_arm64.whl", hash = "sha256:99e1a305c7765631d74b98bf7dbf54eeea931f975e80f115437d23848ee8c27c", size = 219127, upload-time = "2025-08-29T15:33:27.777Z" },
+    { url = "https://files.pythonhosted.org/packages/26/06/263f3305c97ad78aab066d116b52250dd316e74fcc20c197b61e07eb391a/coverage-7.10.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5b2dd6059938063a2c9fee1af729d4f2af28fd1a545e9b7652861f0d752ebcea", size = 217324, upload-time = "2025-08-29T15:33:29.06Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/60/1e1ded9a4fe80d843d7d53b3e395c1db3ff32d6c301e501f393b2e6c1c1f/coverage-7.10.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:388d80e56191bf846c485c14ae2bc8898aa3124d9d35903fef7d907780477634", size = 217560, upload-time = "2025-08-29T15:33:30.748Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/52136173c14e26dfed8b106ed725811bb53c30b896d04d28d74cb64318b3/coverage-7.10.6-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:90cb5b1a4670662719591aa92d0095bb41714970c0b065b02a2610172dbf0af6", size = 249053, upload-time = "2025-08-29T15:33:32.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1d/ae25a7dc58fcce8b172d42ffe5313fc267afe61c97fa872b80ee72d9515a/coverage-7.10.6-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:961834e2f2b863a0e14260a9a273aff07ff7818ab6e66d2addf5628590c628f9", size = 251802, upload-time = "2025-08-29T15:33:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7a/1f561d47743710fe996957ed7c124b421320f150f1d38523d8d9102d3e2a/coverage-7.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf9a19f5012dab774628491659646335b1928cfc931bf8d97b0d5918dd58033c", size = 252935, upload-time = "2025-08-29T15:33:34.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ad/8b97cd5d28aecdfde792dcbf646bac141167a5cacae2cd775998b45fabb5/coverage-7.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99c4283e2a0e147b9c9cc6bc9c96124de9419d6044837e9799763a0e29a7321a", size = 250855, upload-time = "2025-08-29T15:33:36.922Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6a/95c32b558d9a61858ff9d79580d3877df3eb5bc9eed0941b1f187c89e143/coverage-7.10.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:282b1b20f45df57cc508c1e033403f02283adfb67d4c9c35a90281d81e5c52c5", size = 248974, upload-time = "2025-08-29T15:33:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/8ce95dee640a38e760d5b747c10913e7a06554704d60b41e73fdea6a1ffd/coverage-7.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8cdbe264f11afd69841bd8c0d83ca10b5b32853263ee62e6ac6a0ab63895f972", size = 250409, upload-time = "2025-08-29T15:33:39.447Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/7a55b0bdde78a98e2eb2356771fd2dcddb96579e8342bb52aa5bc52e96f0/coverage-7.10.6-cp312-cp312-win32.whl", hash = "sha256:a517feaf3a0a3eca1ee985d8373135cfdedfbba3882a5eab4362bda7c7cf518d", size = 219724, upload-time = "2025-08-29T15:33:41.172Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/32b185b8b8e327802c9efce3d3108d2fe2d9d31f153a0f7ecfd59c773705/coverage-7.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:856986eadf41f52b214176d894a7de05331117f6035a28ac0016c0f63d887629", size = 220536, upload-time = "2025-08-29T15:33:42.524Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3a/d5d8dc703e4998038c3099eaf77adddb00536a3cec08c8dcd556a36a3eb4/coverage-7.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:acf36b8268785aad739443fa2780c16260ee3fa09d12b3a70f772ef100939d80", size = 219171, upload-time = "2025-08-29T15:33:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e7/917e5953ea29a28c1057729c1d5af9084ab6d9c66217523fd0e10f14d8f6/coverage-7.10.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ffea0575345e9ee0144dfe5701aa17f3ba546f8c3bb48db62ae101afb740e7d6", size = 217351, upload-time = "2025-08-29T15:33:45.438Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/86/2e161b93a4f11d0ea93f9bebb6a53f113d5d6e416d7561ca41bb0a29996b/coverage-7.10.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:95d91d7317cde40a1c249d6b7382750b7e6d86fad9d8eaf4fa3f8f44cf171e80", size = 217600, upload-time = "2025-08-29T15:33:47.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/66/d03348fdd8df262b3a7fb4ee5727e6e4936e39e2f3a842e803196946f200/coverage-7.10.6-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3e23dd5408fe71a356b41baa82892772a4cefcf758f2ca3383d2aa39e1b7a003", size = 248600, upload-time = "2025-08-29T15:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/508420fb47d09d904d962f123221bc249f64b5e56aa93d5f5f7603be475f/coverage-7.10.6-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0f3f56e4cb573755e96a16501a98bf211f100463d70275759e73f3cbc00d4f27", size = 251206, upload-time = "2025-08-29T15:33:50.697Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1f/9020135734184f439da85c70ea78194c2730e56c2d18aee6e8ff1719d50d/coverage-7.10.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:db4a1d897bbbe7339946ffa2fe60c10cc81c43fab8b062d3fcb84188688174a4", size = 252478, upload-time = "2025-08-29T15:33:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a4/3d228f3942bb5a2051fde28c136eea23a761177dc4ff4ef54533164ce255/coverage-7.10.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d8fd7879082953c156d5b13c74aa6cca37f6a6f4747b39538504c3f9c63d043d", size = 250637, upload-time = "2025-08-29T15:33:53.67Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e3/293dce8cdb9a83de971637afc59b7190faad60603b40e32635cbd15fbf61/coverage-7.10.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:28395ca3f71cd103b8c116333fa9db867f3a3e1ad6a084aa3725ae002b6583bc", size = 248529, upload-time = "2025-08-29T15:33:55.022Z" },
+    { url = "https://files.pythonhosted.org/packages/90/26/64eecfa214e80dd1d101e420cab2901827de0e49631d666543d0e53cf597/coverage-7.10.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:61c950fc33d29c91b9e18540e1aed7d9f6787cc870a3e4032493bbbe641d12fc", size = 250143, upload-time = "2025-08-29T15:33:56.386Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/70/bd80588338f65ea5b0d97e424b820fb4068b9cfb9597fbd91963086e004b/coverage-7.10.6-cp313-cp313-win32.whl", hash = "sha256:160c00a5e6b6bdf4e5984b0ef21fc860bc94416c41b7df4d63f536d17c38902e", size = 219770, upload-time = "2025-08-29T15:33:58.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/14/0b831122305abcc1060c008f6c97bbdc0a913ab47d65070a01dc50293c2b/coverage-7.10.6-cp313-cp313-win_amd64.whl", hash = "sha256:628055297f3e2aa181464c3808402887643405573eb3d9de060d81531fa79d32", size = 220566, upload-time = "2025-08-29T15:33:59.766Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c6/81a83778c1f83f1a4a168ed6673eeedc205afb562d8500175292ca64b94e/coverage-7.10.6-cp313-cp313-win_arm64.whl", hash = "sha256:df4ec1f8540b0bcbe26ca7dd0f541847cc8a108b35596f9f91f59f0c060bfdd2", size = 219195, upload-time = "2025-08-29T15:34:01.191Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/1c/ccccf4bf116f9517275fa85047495515add43e41dfe8e0bef6e333c6b344/coverage-7.10.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c9a8b7a34a4de3ed987f636f71881cd3b8339f61118b1aa311fbda12741bff0b", size = 218059, upload-time = "2025-08-29T15:34:02.91Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/8a3ceff833d27c7492af4f39d5da6761e9ff624831db9e9f25b3886ddbca/coverage-7.10.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8dd5af36092430c2b075cee966719898f2ae87b636cefb85a653f1d0ba5d5393", size = 218287, upload-time = "2025-08-29T15:34:05.106Z" },
+    { url = "https://files.pythonhosted.org/packages/92/d8/50b4a32580cf41ff0423777a2791aaf3269ab60c840b62009aec12d3970d/coverage-7.10.6-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0353b0f0850d49ada66fdd7d0c7cdb0f86b900bb9e367024fd14a60cecc1e27", size = 259625, upload-time = "2025-08-29T15:34:06.575Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7e/6a7df5a6fb440a0179d94a348eb6616ed4745e7df26bf2a02bc4db72c421/coverage-7.10.6-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d6b9ae13d5d3e8aeca9ca94198aa7b3ebbc5acfada557d724f2a1f03d2c0b0df", size = 261801, upload-time = "2025-08-29T15:34:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/4c/a270a414f4ed5d196b9d3d67922968e768cd971d1b251e1b4f75e9362f75/coverage-7.10.6-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:675824a363cc05781b1527b39dc2587b8984965834a748177ee3c37b64ffeafb", size = 264027, upload-time = "2025-08-29T15:34:09.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/3210d663d594926c12f373c5370bf1e7c5c3a427519a8afa65b561b9a55c/coverage-7.10.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:692d70ea725f471a547c305f0d0fc6a73480c62fb0da726370c088ab21aed282", size = 261576, upload-time = "2025-08-29T15:34:11.585Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d0/e1961eff67e9e1dba3fc5eb7a4caf726b35a5b03776892da8d79ec895775/coverage-7.10.6-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:851430a9a361c7a8484a36126d1d0ff8d529d97385eacc8dfdc9bfc8c2d2cbe4", size = 259341, upload-time = "2025-08-29T15:34:13.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/06/d6478d152cd189b33eac691cba27a40704990ba95de49771285f34a5861e/coverage-7.10.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d9369a23186d189b2fc95cc08b8160ba242057e887d766864f7adf3c46b2df21", size = 260468, upload-time = "2025-08-29T15:34:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/73/737440247c914a332f0b47f7598535b29965bf305e19bbc22d4c39615d2b/coverage-7.10.6-cp313-cp313t-win32.whl", hash = "sha256:92be86fcb125e9bda0da7806afd29a3fd33fdf58fba5d60318399adf40bf37d0", size = 220429, upload-time = "2025-08-29T15:34:16.394Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/76/b92d3214740f2357ef4a27c75a526eb6c28f79c402e9f20a922c295c05e2/coverage-7.10.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6b3039e2ca459a70c79523d39347d83b73f2f06af5624905eba7ec34d64d80b5", size = 221493, upload-time = "2025-08-29T15:34:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8e/6dcb29c599c8a1f654ec6cb68d76644fe635513af16e932d2d4ad1e5ac6e/coverage-7.10.6-cp313-cp313t-win_arm64.whl", hash = "sha256:3fb99d0786fe17b228eab663d16bee2288e8724d26a199c29325aac4b0319b9b", size = 219757, upload-time = "2025-08-29T15:34:19.248Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/aa/76cf0b5ec00619ef208da4689281d48b57f2c7fde883d14bf9441b74d59f/coverage-7.10.6-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6008a021907be8c4c02f37cdc3ffb258493bdebfeaf9a839f9e71dfdc47b018e", size = 217331, upload-time = "2025-08-29T15:34:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/65/91/8e41b8c7c505d398d7730206f3cbb4a875a35ca1041efc518051bfce0f6b/coverage-7.10.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5e75e37f23eb144e78940b40395b42f2321951206a4f50e23cfd6e8a198d3ceb", size = 217607, upload-time = "2025-08-29T15:34:22.433Z" },
+    { url = "https://files.pythonhosted.org/packages/87/7f/f718e732a423d442e6616580a951b8d1ec3575ea48bcd0e2228386805e79/coverage-7.10.6-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0f7cb359a448e043c576f0da00aa8bfd796a01b06aa610ca453d4dde09cc1034", size = 248663, upload-time = "2025-08-29T15:34:24.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/52/c1106120e6d801ac03e12b5285e971e758e925b6f82ee9b86db3aa10045d/coverage-7.10.6-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c68018e4fc4e14b5668f1353b41ccf4bc83ba355f0e1b3836861c6f042d89ac1", size = 251197, upload-time = "2025-08-29T15:34:25.906Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ec/3a8645b1bb40e36acde9c0609f08942852a4af91a937fe2c129a38f2d3f5/coverage-7.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cd4b2b0707fc55afa160cd5fc33b27ccbf75ca11d81f4ec9863d5793fc6df56a", size = 252551, upload-time = "2025-08-29T15:34:27.337Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/70/09ecb68eeb1155b28a1d16525fd3a9b65fbe75337311a99830df935d62b6/coverage-7.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cec13817a651f8804a86e4f79d815b3b28472c910e099e4d5a0e8a3b6a1d4cb", size = 250553, upload-time = "2025-08-29T15:34:29.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/47df374b893fa812e953b5bc93dcb1427a7b3d7a1a7d2db33043d17f74b9/coverage-7.10.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f2a6a8e06bbda06f78739f40bfb56c45d14eb8249d0f0ea6d4b3d48e1f7c695d", size = 248486, upload-time = "2025-08-29T15:34:30.897Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/65/9f98640979ecee1b0d1a7164b589de720ddf8100d1747d9bbdb84be0c0fb/coverage-7.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:081b98395ced0d9bcf60ada7661a0b75f36b78b9d7e39ea0790bb4ed8da14747", size = 249981, upload-time = "2025-08-29T15:34:32.365Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/55/eeb6603371e6629037f47bd25bef300387257ed53a3c5fdb159b7ac8c651/coverage-7.10.6-cp314-cp314-win32.whl", hash = "sha256:6937347c5d7d069ee776b2bf4e1212f912a9f1f141a429c475e6089462fcecc5", size = 220054, upload-time = "2025-08-29T15:34:34.124Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d1/a0912b7611bc35412e919a2cd59ae98e7ea3b475e562668040a43fb27897/coverage-7.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:adec1d980fa07e60b6ef865f9e5410ba760e4e1d26f60f7e5772c73b9a5b0713", size = 220851, upload-time = "2025-08-29T15:34:35.651Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2d/11880bb8ef80a45338e0b3e0725e4c2d73ffbb4822c29d987078224fd6a5/coverage-7.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:a80f7aef9535442bdcf562e5a0d5a5538ce8abe6bb209cfbf170c462ac2c2a32", size = 219429, upload-time = "2025-08-29T15:34:37.16Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c0/1f00caad775c03a700146f55536ecd097a881ff08d310a58b353a1421be0/coverage-7.10.6-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:0de434f4fbbe5af4fa7989521c655c8c779afb61c53ab561b64dcee6149e4c65", size = 218080, upload-time = "2025-08-29T15:34:38.919Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c4/b1c5d2bd7cc412cbeb035e257fd06ed4e3e139ac871d16a07434e145d18d/coverage-7.10.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6e31b8155150c57e5ac43ccd289d079eb3f825187d7c66e755a055d2c85794c6", size = 218293, upload-time = "2025-08-29T15:34:40.425Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/4468d37c94724bf6ec354e4ec2f205fda194343e3e85fd2e59cec57e6a54/coverage-7.10.6-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:98cede73eb83c31e2118ae8d379c12e3e42736903a8afcca92a7218e1f2903b0", size = 259800, upload-time = "2025-08-29T15:34:41.996Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d8/f8fb351be5fee31690cd8da768fd62f1cfab33c31d9f7baba6cd8960f6b8/coverage-7.10.6-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f863c08f4ff6b64fa8045b1e3da480f5374779ef187f07b82e0538c68cb4ff8e", size = 261965, upload-time = "2025-08-29T15:34:43.61Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/70/65d4d7cfc75c5c6eb2fed3ee5cdf420fd8ae09c4808723a89a81d5b1b9c3/coverage-7.10.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b38261034fda87be356f2c3f42221fdb4171c3ce7658066ae449241485390d5", size = 264220, upload-time = "2025-08-29T15:34:45.387Z" },
+    { url = "https://files.pythonhosted.org/packages/98/3c/069df106d19024324cde10e4ec379fe2fb978017d25e97ebee23002fbadf/coverage-7.10.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e93b1476b79eae849dc3872faeb0bf7948fd9ea34869590bc16a2a00b9c82a7", size = 261660, upload-time = "2025-08-29T15:34:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/2974d53904080c5dc91af798b3a54a4ccb99a45595cc0dcec6eb9616a57d/coverage-7.10.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ff8a991f70f4c0cf53088abf1e3886edcc87d53004c7bb94e78650b4d3dac3b5", size = 259417, upload-time = "2025-08-29T15:34:48.779Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/9616a6b49c686394b318974d7f6e08f38b8af2270ce7488e879888d1e5db/coverage-7.10.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ac765b026c9f33044419cbba1da913cfb82cca1b60598ac1c7a5ed6aac4621a0", size = 260567, upload-time = "2025-08-29T15:34:50.718Z" },
+    { url = "https://files.pythonhosted.org/packages/76/16/3ed2d6312b371a8cf804abf4e14895b70e4c3491c6e53536d63fd0958a8d/coverage-7.10.6-cp314-cp314t-win32.whl", hash = "sha256:441c357d55f4936875636ef2cfb3bee36e466dcf50df9afbd398ce79dba1ebb7", size = 220831, upload-time = "2025-08-29T15:34:52.653Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e5/d38d0cb830abede2adb8b147770d2a3d0e7fecc7228245b9b1ae6c24930a/coverage-7.10.6-cp314-cp314t-win_amd64.whl", hash = "sha256:073711de3181b2e204e4870ac83a7c4853115b42e9cd4d145f2231e12d670930", size = 221950, upload-time = "2025-08-29T15:34:54.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/51/e48e550f6279349895b0ffcd6d2a690e3131ba3a7f4eafccc141966d4dea/coverage-7.10.6-cp314-cp314t-win_arm64.whl", hash = "sha256:137921f2bac5559334ba66122b753db6dc5d1cf01eb7b64eb412bb0d064ef35b", size = 219969, upload-time = "2025-08-29T15:34:55.83Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/50db5379b615854b5cf89146f8f5bd1d5a9693d7f3a987e269693521c404/coverage-7.10.6-py3-none-any.whl", hash = "sha256:92c4ecf6bf11b2e85fd4d8204814dc26e6a19f0c9d938c207c5cb0eadfcabbe3", size = 208986, upload-time = "2025-08-29T15:35:14.506Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418, upload-time = "2022-09-25T15:40:01.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259, upload-time = "2022-09-25T15:39:59.68Z" },
 ]
 
 [[package]]
@@ -124,9 +205,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196, upload-time = "2024-11-15T12:30:47.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551, upload-time = "2024-11-15T12:30:45.782Z" },
 ]
 
 [[package]]
@@ -139,27 +220,36 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/df/676b7cf674dd1bdc71a64ad393c89879f75e4a0ab8395165b498262ae106/httpx-0.28.0.tar.gz", hash = "sha256:0858d3bab51ba7e386637f22a61d8ccddaeec5f3fe4209da3a6168dbb91573e0", size = 141307 }
+sdist = { url = "https://files.pythonhosted.org/packages/10/df/676b7cf674dd1bdc71a64ad393c89879f75e4a0ab8395165b498262ae106/httpx-0.28.0.tar.gz", hash = "sha256:0858d3bab51ba7e386637f22a61d8ccddaeec5f3fe4209da3a6168dbb91573e0", size = 141307, upload-time = "2024-11-28T14:54:56.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/fb/a19866137577ba60c6d8b69498dc36be479b13ba454f691348ddf428f185/httpx-0.28.0-py3-none-any.whl", hash = "sha256:dc0b419a0cfeb6e8b34e85167c0da2671206f5095f1baa9663d23bcfd6b535fc", size = 73551 },
+    { url = "https://files.pythonhosted.org/packages/8f/fb/a19866137577ba60c6d8b69498dc36be479b13ba454f691348ddf428f185/httpx-0.28.0-py3-none-any.whl", hash = "sha256:dc0b419a0cfeb6e8b34e85167c0da2671206f5095f1baa9663d23bcfd6b535fc", size = 73551, upload-time = "2024-11-28T14:54:55.141Z" },
 ]
 
 [[package]]
 name = "httpx-sse"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624, upload-time = "2023-12-22T08:01:21.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819, upload-time = "2023-12-22T08:01:19.89Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -174,9 +264,9 @@ dependencies = [
     { name = "sse-starlette" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/f2/067b1fc114e8d3ae4af02fc4f4ed8971a2c4900362d976fabe0f4e9a3418/mcp-1.1.0.tar.gz", hash = "sha256:e3c8d6df93a4de90230ea944dd667730744a3cd91a4cc0ee66a5acd53419e100", size = 83802 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/f2/067b1fc114e8d3ae4af02fc4f4ed8971a2c4900362d976fabe0f4e9a3418/mcp-1.1.0.tar.gz", hash = "sha256:e3c8d6df93a4de90230ea944dd667730744a3cd91a4cc0ee66a5acd53419e100", size = 83802, upload-time = "2024-12-03T22:39:19.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/3e/aef19ac08a6f9a347c086c4e628c2f7329659828cbe92ffd524ec2aac833/mcp-1.1.0-py3-none-any.whl", hash = "sha256:44aa4d2e541f0924d6c344aa7f96b427a6ee1df2fab70b5f9ae2f8777b3f05f2", size = 36576 },
+    { url = "https://files.pythonhosted.org/packages/b9/3e/aef19ac08a6f9a347c086c4e628c2f7329659828cbe92ffd524ec2aac833/mcp-1.1.0-py3-none-any.whl", hash = "sha256:44aa4d2e541f0924d6c344aa7f96b427a6ee1df2fab70b5f9ae2f8777b3f05f2", size = 36576, upload-time = "2024-12-03T22:39:17.88Z" },
 ]
 
 [[package]]
@@ -192,6 +282,11 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "responses" },
 ]
 
 [package.metadata]
@@ -202,15 +297,40 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-mock", specifier = ">=3.12.0" },
+    { name = "responses", specifier = ">=0.24.0" },
+]
 
 [[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -222,9 +342,9 @@ dependencies = [
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/0f/27908242621b14e649a84e62b133de45f84c255eecb350ab02979844a788/pydantic-2.10.3.tar.gz", hash = "sha256:cb5ac360ce894ceacd69c403187900a02c4b20b693a9dd1d643e1effab9eadf9", size = 786486 }
+sdist = { url = "https://files.pythonhosted.org/packages/45/0f/27908242621b14e649a84e62b133de45f84c255eecb350ab02979844a788/pydantic-2.10.3.tar.gz", hash = "sha256:cb5ac360ce894ceacd69c403187900a02c4b20b693a9dd1d643e1effab9eadf9", size = 786486, upload-time = "2024-12-03T15:59:02.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/51/72c18c55cf2f46ff4f91ebcc8f75aa30f7305f3d726be3f4ebffb4ae972b/pydantic-2.10.3-py3-none-any.whl", hash = "sha256:be04d85bbc7b65651c5f8e6b9976ed9c6f41782a55524cef079a34a0bb82144d", size = 456997 },
+    { url = "https://files.pythonhosted.org/packages/62/51/72c18c55cf2f46ff4f91ebcc8f75aa30f7305f3d726be3f4ebffb4ae972b/pydantic-2.10.3-py3-none-any.whl", hash = "sha256:be04d85bbc7b65651c5f8e6b9976ed9c6f41782a55524cef079a34a0bb82144d", size = 456997, upload-time = "2024-12-03T15:58:59.867Z" },
 ]
 
 [[package]]
@@ -234,50 +354,59 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/9f/7de1f19b6aea45aeb441838782d68352e71bfa98ee6fa048d5041991b33e/pydantic_core-2.27.1.tar.gz", hash = "sha256:62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235", size = 412785 }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/9f/7de1f19b6aea45aeb441838782d68352e71bfa98ee6fa048d5041991b33e/pydantic_core-2.27.1.tar.gz", hash = "sha256:62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235", size = 412785, upload-time = "2024-11-22T00:24:49.865Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/39/46fe47f2ad4746b478ba89c561cafe4428e02b3573df882334bd2964f9cb/pydantic_core-2.27.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ac3b20653bdbe160febbea8aa6c079d3df19310d50ac314911ed8cc4eb7f8cb8", size = 1895553 },
-    { url = "https://files.pythonhosted.org/packages/1c/00/0804e84a78b7fdb394fff4c4f429815a10e5e0993e6ae0e0b27dd20379ee/pydantic_core-2.27.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a5a8e19d7c707c4cadb8c18f5f60c843052ae83c20fa7d44f41594c644a1d330", size = 1807220 },
-    { url = "https://files.pythonhosted.org/packages/01/de/df51b3bac9820d38371f5a261020f505025df732ce566c2a2e7970b84c8c/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f7059ca8d64fea7f238994c97d91f75965216bcbe5f695bb44f354893f11d52", size = 1829727 },
-    { url = "https://files.pythonhosted.org/packages/5f/d9/c01d19da8f9e9fbdb2bf99f8358d145a312590374d0dc9dd8dbe484a9cde/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bed0f8a0eeea9fb72937ba118f9db0cb7e90773462af7962d382445f3005e5a4", size = 1854282 },
-    { url = "https://files.pythonhosted.org/packages/5f/84/7db66eb12a0dc88c006abd6f3cbbf4232d26adfd827a28638c540d8f871d/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3cb37038123447cf0f3ea4c74751f6a9d7afef0eb71aa07bf5f652b5e6a132c", size = 2037437 },
-    { url = "https://files.pythonhosted.org/packages/34/ac/a2537958db8299fbabed81167d58cc1506049dba4163433524e06a7d9f4c/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:84286494f6c5d05243456e04223d5a9417d7f443c3b76065e75001beb26f88de", size = 2780899 },
-    { url = "https://files.pythonhosted.org/packages/4a/c1/3e38cd777ef832c4fdce11d204592e135ddeedb6c6f525478a53d1c7d3e5/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acc07b2cfc5b835444b44a9956846b578d27beeacd4b52e45489e93276241025", size = 2135022 },
-    { url = "https://files.pythonhosted.org/packages/7a/69/b9952829f80fd555fe04340539d90e000a146f2a003d3fcd1e7077c06c71/pydantic_core-2.27.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4fefee876e07a6e9aad7a8c8c9f85b0cdbe7df52b8a9552307b09050f7512c7e", size = 1987969 },
-    { url = "https://files.pythonhosted.org/packages/05/72/257b5824d7988af43460c4e22b63932ed651fe98804cc2793068de7ec554/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:258c57abf1188926c774a4c94dd29237e77eda19462e5bb901d88adcab6af919", size = 1994625 },
-    { url = "https://files.pythonhosted.org/packages/73/c3/78ed6b7f3278a36589bcdd01243189ade7fc9b26852844938b4d7693895b/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:35c14ac45fcfdf7167ca76cc80b2001205a8d5d16d80524e13508371fb8cdd9c", size = 2090089 },
-    { url = "https://files.pythonhosted.org/packages/8d/c8/b4139b2f78579960353c4cd987e035108c93a78371bb19ba0dc1ac3b3220/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d1b26e1dff225c31897696cab7d4f0a315d4c0d9e8666dbffdb28216f3b17fdc", size = 2142496 },
-    { url = "https://files.pythonhosted.org/packages/3e/f8/171a03e97eb36c0b51981efe0f78460554a1d8311773d3d30e20c005164e/pydantic_core-2.27.1-cp311-none-win32.whl", hash = "sha256:2cdf7d86886bc6982354862204ae3b2f7f96f21a3eb0ba5ca0ac42c7b38598b9", size = 1811758 },
-    { url = "https://files.pythonhosted.org/packages/6a/fe/4e0e63c418c1c76e33974a05266e5633e879d4061f9533b1706a86f77d5b/pydantic_core-2.27.1-cp311-none-win_amd64.whl", hash = "sha256:3af385b0cee8df3746c3f406f38bcbfdc9041b5c2d5ce3e5fc6637256e60bbc5", size = 1980864 },
-    { url = "https://files.pythonhosted.org/packages/50/fc/93f7238a514c155a8ec02fc7ac6376177d449848115e4519b853820436c5/pydantic_core-2.27.1-cp311-none-win_arm64.whl", hash = "sha256:81f2ec23ddc1b476ff96563f2e8d723830b06dceae348ce02914a37cb4e74b89", size = 1864327 },
-    { url = "https://files.pythonhosted.org/packages/be/51/2e9b3788feb2aebff2aa9dfbf060ec739b38c05c46847601134cc1fed2ea/pydantic_core-2.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9cbd94fc661d2bab2bc702cddd2d3370bbdcc4cd0f8f57488a81bcce90c7a54f", size = 1895239 },
-    { url = "https://files.pythonhosted.org/packages/7b/9e/f8063952e4a7d0127f5d1181addef9377505dcce3be224263b25c4f0bfd9/pydantic_core-2.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f8c4718cd44ec1580e180cb739713ecda2bdee1341084c1467802a417fe0f02", size = 1805070 },
-    { url = "https://files.pythonhosted.org/packages/2c/9d/e1d6c4561d262b52e41b17a7ef8301e2ba80b61e32e94520271029feb5d8/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15aae984e46de8d376df515f00450d1522077254ef6b7ce189b38ecee7c9677c", size = 1828096 },
-    { url = "https://files.pythonhosted.org/packages/be/65/80ff46de4266560baa4332ae3181fffc4488ea7d37282da1a62d10ab89a4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ba5e3963344ff25fc8c40da90f44b0afca8cfd89d12964feb79ac1411a260ac", size = 1857708 },
-    { url = "https://files.pythonhosted.org/packages/d5/ca/3370074ad758b04d9562b12ecdb088597f4d9d13893a48a583fb47682cdf/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:992cea5f4f3b29d6b4f7f1726ed8ee46c8331c6b4eed6db5b40134c6fe1768bb", size = 2037751 },
-    { url = "https://files.pythonhosted.org/packages/b1/e2/4ab72d93367194317b99d051947c071aef6e3eb95f7553eaa4208ecf9ba4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0325336f348dbee6550d129b1627cb8f5351a9dc91aad141ffb96d4937bd9529", size = 2733863 },
-    { url = "https://files.pythonhosted.org/packages/8a/c6/8ae0831bf77f356bb73127ce5a95fe115b10f820ea480abbd72d3cc7ccf3/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7597c07fbd11515f654d6ece3d0e4e5093edc30a436c63142d9a4b8e22f19c35", size = 2161161 },
-    { url = "https://files.pythonhosted.org/packages/f1/f4/b2fe73241da2429400fc27ddeaa43e35562f96cf5b67499b2de52b528cad/pydantic_core-2.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3bbd5d8cc692616d5ef6fbbbd50dbec142c7e6ad9beb66b78a96e9c16729b089", size = 1993294 },
-    { url = "https://files.pythonhosted.org/packages/77/29/4bb008823a7f4cc05828198153f9753b3bd4c104d93b8e0b1bfe4e187540/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:dc61505e73298a84a2f317255fcc72b710b72980f3a1f670447a21efc88f8381", size = 2001468 },
-    { url = "https://files.pythonhosted.org/packages/f2/a9/0eaceeba41b9fad851a4107e0cf999a34ae8f0d0d1f829e2574f3d8897b0/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:e1f735dc43da318cad19b4173dd1ffce1d84aafd6c9b782b3abc04a0d5a6f5bb", size = 2091413 },
-    { url = "https://files.pythonhosted.org/packages/d8/36/eb8697729725bc610fd73940f0d860d791dc2ad557faaefcbb3edbd2b349/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f4e5658dbffe8843a0f12366a4c2d1c316dbe09bb4dfbdc9d2d9cd6031de8aae", size = 2154735 },
-    { url = "https://files.pythonhosted.org/packages/52/e5/4f0fbd5c5995cc70d3afed1b5c754055bb67908f55b5cb8000f7112749bf/pydantic_core-2.27.1-cp312-none-win32.whl", hash = "sha256:672ebbe820bb37988c4d136eca2652ee114992d5d41c7e4858cdd90ea94ffe5c", size = 1833633 },
-    { url = "https://files.pythonhosted.org/packages/ee/f2/c61486eee27cae5ac781305658779b4a6b45f9cc9d02c90cb21b940e82cc/pydantic_core-2.27.1-cp312-none-win_amd64.whl", hash = "sha256:66ff044fd0bb1768688aecbe28b6190f6e799349221fb0de0e6f4048eca14c16", size = 1986973 },
-    { url = "https://files.pythonhosted.org/packages/df/a6/e3f12ff25f250b02f7c51be89a294689d175ac76e1096c32bf278f29ca1e/pydantic_core-2.27.1-cp312-none-win_arm64.whl", hash = "sha256:9a3b0793b1bbfd4146304e23d90045f2a9b5fd5823aa682665fbdaf2a6c28f3e", size = 1883215 },
-    { url = "https://files.pythonhosted.org/packages/0f/d6/91cb99a3c59d7b072bded9959fbeab0a9613d5a4935773c0801f1764c156/pydantic_core-2.27.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f216dbce0e60e4d03e0c4353c7023b202d95cbaeff12e5fd2e82ea0a66905073", size = 1895033 },
-    { url = "https://files.pythonhosted.org/packages/07/42/d35033f81a28b27dedcade9e967e8a40981a765795c9ebae2045bcef05d3/pydantic_core-2.27.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a2e02889071850bbfd36b56fd6bc98945e23670773bc7a76657e90e6b6603c08", size = 1807542 },
-    { url = "https://files.pythonhosted.org/packages/41/c2/491b59e222ec7e72236e512108ecad532c7f4391a14e971c963f624f7569/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42b0e23f119b2b456d07ca91b307ae167cc3f6c846a7b169fca5326e32fdc6cf", size = 1827854 },
-    { url = "https://files.pythonhosted.org/packages/e3/f3/363652651779113189cefdbbb619b7b07b7a67ebb6840325117cc8cc3460/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:764be71193f87d460a03f1f7385a82e226639732214b402f9aa61f0d025f0737", size = 1857389 },
-    { url = "https://files.pythonhosted.org/packages/5f/97/be804aed6b479af5a945daec7538d8bf358d668bdadde4c7888a2506bdfb/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c00666a3bd2f84920a4e94434f5974d7bbc57e461318d6bb34ce9cdbbc1f6b2", size = 2037934 },
-    { url = "https://files.pythonhosted.org/packages/42/01/295f0bd4abf58902917e342ddfe5f76cf66ffabfc57c2e23c7681a1a1197/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ccaa88b24eebc0f849ce0a4d09e8a408ec5a94afff395eb69baf868f5183107", size = 2735176 },
-    { url = "https://files.pythonhosted.org/packages/9d/a0/cd8e9c940ead89cc37812a1a9f310fef59ba2f0b22b4e417d84ab09fa970/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c65af9088ac534313e1963443d0ec360bb2b9cba6c2909478d22c2e363d98a51", size = 2160720 },
-    { url = "https://files.pythonhosted.org/packages/73/ae/9d0980e286627e0aeca4c352a60bd760331622c12d576e5ea4441ac7e15e/pydantic_core-2.27.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206b5cf6f0c513baffaeae7bd817717140770c74528f3e4c3e1cec7871ddd61a", size = 1992972 },
-    { url = "https://files.pythonhosted.org/packages/bf/ba/ae4480bc0292d54b85cfb954e9d6bd226982949f8316338677d56541b85f/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:062f60e512fc7fff8b8a9d680ff0ddaaef0193dba9fa83e679c0c5f5fbd018bc", size = 2001477 },
-    { url = "https://files.pythonhosted.org/packages/55/b7/e26adf48c2f943092ce54ae14c3c08d0d221ad34ce80b18a50de8ed2cba8/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:a0697803ed7d4af5e4c1adf1670af078f8fcab7a86350e969f454daf598c4960", size = 2091186 },
-    { url = "https://files.pythonhosted.org/packages/ba/cc/8491fff5b608b3862eb36e7d29d36a1af1c945463ca4c5040bf46cc73f40/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:58ca98a950171f3151c603aeea9303ef6c235f692fe555e883591103da709b23", size = 2154429 },
-    { url = "https://files.pythonhosted.org/packages/78/d8/c080592d80edd3441ab7f88f865f51dae94a157fc64283c680e9f32cf6da/pydantic_core-2.27.1-cp313-none-win32.whl", hash = "sha256:8065914ff79f7eab1599bd80406681f0ad08f8e47c880f17b416c9f8f7a26d05", size = 1833713 },
-    { url = "https://files.pythonhosted.org/packages/83/84/5ab82a9ee2538ac95a66e51f6838d6aba6e0a03a42aa185ad2fe404a4e8f/pydantic_core-2.27.1-cp313-none-win_amd64.whl", hash = "sha256:ba630d5e3db74c79300d9a5bdaaf6200172b107f263c98a0539eeecb857b2337", size = 1987897 },
-    { url = "https://files.pythonhosted.org/packages/df/c3/b15fb833926d91d982fde29c0624c9f225da743c7af801dace0d4e187e71/pydantic_core-2.27.1-cp313-none-win_arm64.whl", hash = "sha256:45cf8588c066860b623cd11c4ba687f8d7175d5f7ef65f7129df8a394c502de5", size = 1882983 },
+    { url = "https://files.pythonhosted.org/packages/27/39/46fe47f2ad4746b478ba89c561cafe4428e02b3573df882334bd2964f9cb/pydantic_core-2.27.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ac3b20653bdbe160febbea8aa6c079d3df19310d50ac314911ed8cc4eb7f8cb8", size = 1895553, upload-time = "2024-11-22T00:21:48.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/00/0804e84a78b7fdb394fff4c4f429815a10e5e0993e6ae0e0b27dd20379ee/pydantic_core-2.27.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a5a8e19d7c707c4cadb8c18f5f60c843052ae83c20fa7d44f41594c644a1d330", size = 1807220, upload-time = "2024-11-22T00:21:50.354Z" },
+    { url = "https://files.pythonhosted.org/packages/01/de/df51b3bac9820d38371f5a261020f505025df732ce566c2a2e7970b84c8c/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f7059ca8d64fea7f238994c97d91f75965216bcbe5f695bb44f354893f11d52", size = 1829727, upload-time = "2024-11-22T00:21:51.722Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d9/c01d19da8f9e9fbdb2bf99f8358d145a312590374d0dc9dd8dbe484a9cde/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bed0f8a0eeea9fb72937ba118f9db0cb7e90773462af7962d382445f3005e5a4", size = 1854282, upload-time = "2024-11-22T00:21:53.098Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/84/7db66eb12a0dc88c006abd6f3cbbf4232d26adfd827a28638c540d8f871d/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3cb37038123447cf0f3ea4c74751f6a9d7afef0eb71aa07bf5f652b5e6a132c", size = 2037437, upload-time = "2024-11-22T00:21:55.185Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ac/a2537958db8299fbabed81167d58cc1506049dba4163433524e06a7d9f4c/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:84286494f6c5d05243456e04223d5a9417d7f443c3b76065e75001beb26f88de", size = 2780899, upload-time = "2024-11-22T00:21:56.633Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c1/3e38cd777ef832c4fdce11d204592e135ddeedb6c6f525478a53d1c7d3e5/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acc07b2cfc5b835444b44a9956846b578d27beeacd4b52e45489e93276241025", size = 2135022, upload-time = "2024-11-22T00:21:59.154Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/69/b9952829f80fd555fe04340539d90e000a146f2a003d3fcd1e7077c06c71/pydantic_core-2.27.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4fefee876e07a6e9aad7a8c8c9f85b0cdbe7df52b8a9552307b09050f7512c7e", size = 1987969, upload-time = "2024-11-22T00:22:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/72/257b5824d7988af43460c4e22b63932ed651fe98804cc2793068de7ec554/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:258c57abf1188926c774a4c94dd29237e77eda19462e5bb901d88adcab6af919", size = 1994625, upload-time = "2024-11-22T00:22:03.447Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c3/78ed6b7f3278a36589bcdd01243189ade7fc9b26852844938b4d7693895b/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:35c14ac45fcfdf7167ca76cc80b2001205a8d5d16d80524e13508371fb8cdd9c", size = 2090089, upload-time = "2024-11-22T00:22:04.941Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c8/b4139b2f78579960353c4cd987e035108c93a78371bb19ba0dc1ac3b3220/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d1b26e1dff225c31897696cab7d4f0a315d4c0d9e8666dbffdb28216f3b17fdc", size = 2142496, upload-time = "2024-11-22T00:22:06.57Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f8/171a03e97eb36c0b51981efe0f78460554a1d8311773d3d30e20c005164e/pydantic_core-2.27.1-cp311-none-win32.whl", hash = "sha256:2cdf7d86886bc6982354862204ae3b2f7f96f21a3eb0ba5ca0ac42c7b38598b9", size = 1811758, upload-time = "2024-11-22T00:22:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fe/4e0e63c418c1c76e33974a05266e5633e879d4061f9533b1706a86f77d5b/pydantic_core-2.27.1-cp311-none-win_amd64.whl", hash = "sha256:3af385b0cee8df3746c3f406f38bcbfdc9041b5c2d5ce3e5fc6637256e60bbc5", size = 1980864, upload-time = "2024-11-22T00:22:10Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fc/93f7238a514c155a8ec02fc7ac6376177d449848115e4519b853820436c5/pydantic_core-2.27.1-cp311-none-win_arm64.whl", hash = "sha256:81f2ec23ddc1b476ff96563f2e8d723830b06dceae348ce02914a37cb4e74b89", size = 1864327, upload-time = "2024-11-22T00:22:11.478Z" },
+    { url = "https://files.pythonhosted.org/packages/be/51/2e9b3788feb2aebff2aa9dfbf060ec739b38c05c46847601134cc1fed2ea/pydantic_core-2.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9cbd94fc661d2bab2bc702cddd2d3370bbdcc4cd0f8f57488a81bcce90c7a54f", size = 1895239, upload-time = "2024-11-22T00:22:13.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9e/f8063952e4a7d0127f5d1181addef9377505dcce3be224263b25c4f0bfd9/pydantic_core-2.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f8c4718cd44ec1580e180cb739713ecda2bdee1341084c1467802a417fe0f02", size = 1805070, upload-time = "2024-11-22T00:22:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9d/e1d6c4561d262b52e41b17a7ef8301e2ba80b61e32e94520271029feb5d8/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15aae984e46de8d376df515f00450d1522077254ef6b7ce189b38ecee7c9677c", size = 1828096, upload-time = "2024-11-22T00:22:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/be/65/80ff46de4266560baa4332ae3181fffc4488ea7d37282da1a62d10ab89a4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ba5e3963344ff25fc8c40da90f44b0afca8cfd89d12964feb79ac1411a260ac", size = 1857708, upload-time = "2024-11-22T00:22:19.412Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ca/3370074ad758b04d9562b12ecdb088597f4d9d13893a48a583fb47682cdf/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:992cea5f4f3b29d6b4f7f1726ed8ee46c8331c6b4eed6db5b40134c6fe1768bb", size = 2037751, upload-time = "2024-11-22T00:22:20.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/4ab72d93367194317b99d051947c071aef6e3eb95f7553eaa4208ecf9ba4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0325336f348dbee6550d129b1627cb8f5351a9dc91aad141ffb96d4937bd9529", size = 2733863, upload-time = "2024-11-22T00:22:22.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c6/8ae0831bf77f356bb73127ce5a95fe115b10f820ea480abbd72d3cc7ccf3/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7597c07fbd11515f654d6ece3d0e4e5093edc30a436c63142d9a4b8e22f19c35", size = 2161161, upload-time = "2024-11-22T00:22:24.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f4/b2fe73241da2429400fc27ddeaa43e35562f96cf5b67499b2de52b528cad/pydantic_core-2.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3bbd5d8cc692616d5ef6fbbbd50dbec142c7e6ad9beb66b78a96e9c16729b089", size = 1993294, upload-time = "2024-11-22T00:22:27.076Z" },
+    { url = "https://files.pythonhosted.org/packages/77/29/4bb008823a7f4cc05828198153f9753b3bd4c104d93b8e0b1bfe4e187540/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:dc61505e73298a84a2f317255fcc72b710b72980f3a1f670447a21efc88f8381", size = 2001468, upload-time = "2024-11-22T00:22:29.346Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a9/0eaceeba41b9fad851a4107e0cf999a34ae8f0d0d1f829e2574f3d8897b0/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:e1f735dc43da318cad19b4173dd1ffce1d84aafd6c9b782b3abc04a0d5a6f5bb", size = 2091413, upload-time = "2024-11-22T00:22:30.984Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/eb8697729725bc610fd73940f0d860d791dc2ad557faaefcbb3edbd2b349/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f4e5658dbffe8843a0f12366a4c2d1c316dbe09bb4dfbdc9d2d9cd6031de8aae", size = 2154735, upload-time = "2024-11-22T00:22:32.616Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e5/4f0fbd5c5995cc70d3afed1b5c754055bb67908f55b5cb8000f7112749bf/pydantic_core-2.27.1-cp312-none-win32.whl", hash = "sha256:672ebbe820bb37988c4d136eca2652ee114992d5d41c7e4858cdd90ea94ffe5c", size = 1833633, upload-time = "2024-11-22T00:22:35.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f2/c61486eee27cae5ac781305658779b4a6b45f9cc9d02c90cb21b940e82cc/pydantic_core-2.27.1-cp312-none-win_amd64.whl", hash = "sha256:66ff044fd0bb1768688aecbe28b6190f6e799349221fb0de0e6f4048eca14c16", size = 1986973, upload-time = "2024-11-22T00:22:37.502Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a6/e3f12ff25f250b02f7c51be89a294689d175ac76e1096c32bf278f29ca1e/pydantic_core-2.27.1-cp312-none-win_arm64.whl", hash = "sha256:9a3b0793b1bbfd4146304e23d90045f2a9b5fd5823aa682665fbdaf2a6c28f3e", size = 1883215, upload-time = "2024-11-22T00:22:39.186Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/d6/91cb99a3c59d7b072bded9959fbeab0a9613d5a4935773c0801f1764c156/pydantic_core-2.27.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f216dbce0e60e4d03e0c4353c7023b202d95cbaeff12e5fd2e82ea0a66905073", size = 1895033, upload-time = "2024-11-22T00:22:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/d35033f81a28b27dedcade9e967e8a40981a765795c9ebae2045bcef05d3/pydantic_core-2.27.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a2e02889071850bbfd36b56fd6bc98945e23670773bc7a76657e90e6b6603c08", size = 1807542, upload-time = "2024-11-22T00:22:43.341Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c2/491b59e222ec7e72236e512108ecad532c7f4391a14e971c963f624f7569/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42b0e23f119b2b456d07ca91b307ae167cc3f6c846a7b169fca5326e32fdc6cf", size = 1827854, upload-time = "2024-11-22T00:22:44.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f3/363652651779113189cefdbbb619b7b07b7a67ebb6840325117cc8cc3460/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:764be71193f87d460a03f1f7385a82e226639732214b402f9aa61f0d025f0737", size = 1857389, upload-time = "2024-11-22T00:22:47.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/be804aed6b479af5a945daec7538d8bf358d668bdadde4c7888a2506bdfb/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c00666a3bd2f84920a4e94434f5974d7bbc57e461318d6bb34ce9cdbbc1f6b2", size = 2037934, upload-time = "2024-11-22T00:22:49.093Z" },
+    { url = "https://files.pythonhosted.org/packages/42/01/295f0bd4abf58902917e342ddfe5f76cf66ffabfc57c2e23c7681a1a1197/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ccaa88b24eebc0f849ce0a4d09e8a408ec5a94afff395eb69baf868f5183107", size = 2735176, upload-time = "2024-11-22T00:22:50.822Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/a0/cd8e9c940ead89cc37812a1a9f310fef59ba2f0b22b4e417d84ab09fa970/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c65af9088ac534313e1963443d0ec360bb2b9cba6c2909478d22c2e363d98a51", size = 2160720, upload-time = "2024-11-22T00:22:52.638Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ae/9d0980e286627e0aeca4c352a60bd760331622c12d576e5ea4441ac7e15e/pydantic_core-2.27.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206b5cf6f0c513baffaeae7bd817717140770c74528f3e4c3e1cec7871ddd61a", size = 1992972, upload-time = "2024-11-22T00:22:54.31Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ba/ae4480bc0292d54b85cfb954e9d6bd226982949f8316338677d56541b85f/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:062f60e512fc7fff8b8a9d680ff0ddaaef0193dba9fa83e679c0c5f5fbd018bc", size = 2001477, upload-time = "2024-11-22T00:22:56.451Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b7/e26adf48c2f943092ce54ae14c3c08d0d221ad34ce80b18a50de8ed2cba8/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:a0697803ed7d4af5e4c1adf1670af078f8fcab7a86350e969f454daf598c4960", size = 2091186, upload-time = "2024-11-22T00:22:58.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/8491fff5b608b3862eb36e7d29d36a1af1c945463ca4c5040bf46cc73f40/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:58ca98a950171f3151c603aeea9303ef6c235f692fe555e883591103da709b23", size = 2154429, upload-time = "2024-11-22T00:22:59.985Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d8/c080592d80edd3441ab7f88f865f51dae94a157fc64283c680e9f32cf6da/pydantic_core-2.27.1-cp313-none-win32.whl", hash = "sha256:8065914ff79f7eab1599bd80406681f0ad08f8e47c880f17b416c9f8f7a26d05", size = 1833713, upload-time = "2024-11-22T00:23:01.715Z" },
+    { url = "https://files.pythonhosted.org/packages/83/84/5ab82a9ee2538ac95a66e51f6838d6aba6e0a03a42aa185ad2fe404a4e8f/pydantic_core-2.27.1-cp313-none-win_amd64.whl", hash = "sha256:ba630d5e3db74c79300d9a5bdaaf6200172b107f263c98a0539eeecb857b2337", size = 1987897, upload-time = "2024-11-22T00:23:03.497Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c3/b15fb833926d91d982fde29c0624c9f225da743c7af801dace0d4e187e71/pydantic_core-2.27.1-cp313-none-win_arm64.whl", hash = "sha256:45cf8588c066860b623cd11c4ba687f8d7175d5f7ef65f7129df8a394c502de5", size = 1882983, upload-time = "2024-11-22T00:23:05.983Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -288,18 +417,107 @@ dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940, upload-time = "2024-11-13T16:35:41.84Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581, upload-time = "2024-11-13T16:35:40.689Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241, upload-time = "2025-05-26T13:58:45.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923, upload-time = "2025-05-26T13:58:43.487Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
 ]
 
 [[package]]
@@ -312,18 +530,32 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.25.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/95/89c054ad70bfef6da605338b009b2e283485835351a9935c7bfbfaca7ffc/responses-0.25.8.tar.gz", hash = "sha256:9374d047a575c8f781b94454db5cab590b6029505f488d12899ddb10a4af1cf4", size = 79320, upload-time = "2025-08-08T19:01:46.709Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl", hash = "sha256:0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c", size = 34769, upload-time = "2025-08-08T19:01:45.018Z" },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -335,9 +567,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/fc/56ab9f116b2133521f532fce8d03194cf04dcac25f583cf3d839be4c0496/sse_starlette-2.1.3.tar.gz", hash = "sha256:9cd27eb35319e1414e3d2558ee7414487f9529ce3b3cf9b21434fd110e017169", size = 19678 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/fc/56ab9f116b2133521f532fce8d03194cf04dcac25f583cf3d839be4c0496/sse_starlette-2.1.3.tar.gz", hash = "sha256:9cd27eb35319e1414e3d2558ee7414487f9529ce3b3cf9b21434fd110e017169", size = 19678, upload-time = "2024-08-01T08:52:50.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/aa/36b271bc4fa1d2796311ee7c7283a3a1c348bad426d37293609ca4300eef/sse_starlette-2.1.3-py3-none-any.whl", hash = "sha256:8ec846438b4665b9e8c560fcdea6bc8081a3abf7942faa95e5a744999d219772", size = 9383 },
+    { url = "https://files.pythonhosted.org/packages/52/aa/36b271bc4fa1d2796311ee7c7283a3a1c348bad426d37293609ca4300eef/sse_starlette-2.1.3-py3-none-any.whl", hash = "sha256:8ec846438b4665b9e8c560fcdea6bc8081a3abf7942faa95e5a744999d219772", size = 9383, upload-time = "2024-08-01T08:52:48.659Z" },
 ]
 
 [[package]]
@@ -347,27 +579,66 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/4c/9b5764bd22eec91c4039ef4c55334e9187085da2d8a2df7bd570869aae18/starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835", size = 2574159 }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/4c/9b5764bd22eec91c4039ef4c55334e9187085da2d8a2df7bd570869aae18/starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835", size = 2574159, upload-time = "2024-11-18T19:45:04.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/00/2b325970b3060c7cecebab6d295afe763365822b1306a12eeab198f74323/starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7", size = 73225 },
+    { url = "https://files.pythonhosted.org/packages/96/00/2b325970b3060c7cecebab6d295afe763365822b1306a12eeab198f74323/starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7", size = 73225, upload-time = "2024-11-18T19:45:02.027Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677 }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338 },
+    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
 ]
 
 [[package]]
@@ -378,7 +649,7 @@ dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/3c/21dba3e7d76138725ef307e3d7ddd29b763119b3aa459d02cc05fefcff75/uvicorn-0.32.1.tar.gz", hash = "sha256:ee9519c246a72b1c084cea8d3b44ed6026e78a4a309cbedae9c37e4cb9fbb175", size = 77630 }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/3c/21dba3e7d76138725ef307e3d7ddd29b763119b3aa459d02cc05fefcff75/uvicorn-0.32.1.tar.gz", hash = "sha256:ee9519c246a72b1c084cea8d3b44ed6026e78a4a309cbedae9c37e4cb9fbb175", size = 77630, upload-time = "2024-11-20T19:41:13.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/c1/2d27b0a15826c2b71dcf6e2f5402181ef85acf439617bb2f1453125ce1f3/uvicorn-0.32.1-py3-none-any.whl", hash = "sha256:82ad92fd58da0d12af7482ecdb5f2470a04c9c9a53ced65b9bbb4a205377602e", size = 63828 },
+    { url = "https://files.pythonhosted.org/packages/50/c1/2d27b0a15826c2b71dcf6e2f5402181ef85acf439617bb2f1453125ce1f3/uvicorn-0.32.1-py3-none-any.whl", hash = "sha256:82ad92fd58da0d12af7482ecdb5f2470a04c9c9a53ced65b9bbb4a205377602e", size = 63828, upload-time = "2024-11-20T19:41:11.244Z" },
 ]


### PR DESCRIPTION
**Motivation**: I intend to add one CLI-related feature: a simple option `--vault-dir` to point to an Obsidian Vault home and autodetect proper configuration parameters from the Local REST API Obsidian plugin.
This PR does not include the `--vault-dir` feature; it would be built on this PR if accepted.

**Actual PR content**
To do this, I need an easy-to-use CLI, and I found the existing version not as easy to deal with.
To make the CLI, I had to prepare:
- test suite (to check that changes did not break things)
- configuration validation (based on pydantic settings) so that we are safe when running or fail quickly on broken config values
- updated documentation
  - README.md: how to use it and configure. Lists all available env variables
  - docs/CONFIG.md: configuration concepts explained
  - docs/CONFIG_MIGRATION.md: explains how to migrate from existing configurations to match the new configuration style
It works for me (tested with Claude Desktop).