### PR TITLE
Normalize `dirpath` to handle trailing slashes consistently

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -80,9 +80,11 @@ class ListFilesInDirToolHandler(ToolHandler):
         if "dirpath" not in args:
             raise RuntimeError("dirpath argument missing in arguments")
 
+        # Normalize dirpath by removing trailing slash for consistent API behavior
+        dirpath = args["dirpath"].rstrip("/")
         api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
 
-        files = api.list_files_in_dir(args["dirpath"])
+        files = api.list_files_in_dir(dirpath)
 
         return [
             TextContent(


### PR DESCRIPTION
## Problem

The API has an inconsistent path format requirement that presents a usability issue:

- `obsidian_list_files_in_vault` returns directory names **with** trailing slashes: `["Journal/", "Projects/"]`
- `obsidian_list_files_in_dir` requires paths **without** trailing slashes: `{"dirpath": "Journal"}` works, but `{"dirpath": "Journal/"}` returns Error 40400

This makes it difficult to chain API calls, as users naturally copy directory names from listing responses but get errors when using them as inputs. This creates a usability issue where the API's inconsistent path handling causes confusion and errors when chaining API calls.

## Solution

This PR adds path normalization in the `ListFilesInDirToolHandler.run_tool()` method to strip trailing slashes from the `dirpath` parameter before making the API call.

### Changes

- Added `dirpath.rstrip('/')` to normalize paths
- Updated API call to use normalized `dirpath` variable
- Added inline comment explaining the normalization

### Code Changes

```python
# Before
files = api.list_files_in_dir(args["dirpath"])

# After
# Normalize dirpath by removing trailing slash for consistent API behavior
dirpath = args["dirpath"].rstrip("/")
files = api.list_files_in_dir(dirpath)
```

## Impact

### Before This Fix
```bash
# Step 1: List vault directories (returns with trailing slashes)
curl -X POST http://localhost:8000/obsidian/obsidian_list_files_in_vault \
  -H "Content-Type: application/json" -d '{}'
# Returns: ["Journal/", "Projects/", ...]

# Step 2: Try to list files in "Journal/" (FAILS)
curl -X POST http://localhost:8000/obsidian/obsidian_list_files_in_dir \
  -H "Content-Type: application/json" -d '{"dirpath": "Journal/"}'
# Returns: Error 40400: Not Found

# Step 3: Remove trailing slash manually (WORKS)
curl -X POST http://localhost:8000/obsidian/obsidian_list_files_in_dir \
  -H "Content-Type: application/json" -d '{"dirpath": "Journal"}'
# Returns: ["file1.md", "file2.md", ...]
```

### After This Fix
```bash
# Both formats now work correctly
curl -X POST http://localhost:8000/obsidian/obsidian_list_files_in_dir \
  -H "Content-Type: application/json" -d '{"dirpath": "Journal/"}'
# Returns: ["file1.md", "file2.md", ...]

curl -X POST http://localhost:8000/obsidian/obsidian_list_files_in_dir \
  -H "Content-Type: application/json" -d '{"dirpath": "Journal"}'
# Returns: ["file1.md", "file2.md", ...]
```

## Benefits

1. **Improved User Experience**: Users can now use directory names directly from `list_files_in_vault` responses
2. **API Consistency**: Both input and output formats are now compatible
3. **Follows Best Practices**: Implements "be liberal in what you accept" principle
4. **Backward Compatible**: Paths without trailing slashes continue to work as before
5. **Minimal Change**: Simple, focused fix with no breaking changes

## Testing

Tested with:
- Paths without trailing slashes: `"Journal"`
- Paths with trailing slashes: `"Journal/"`
- Nested paths: `"Journal/Daily"`
- Nested paths with trailing slash: `"Journal/Daily/"`