### PR TITLE
feat: add optional features for large vaults and SSL certificate support

### DIFF
--- a/JOURNALING.md
+++ b/JOURNALING.md
@@ -1,0 +1,261 @@
+# Agent Journaling Guide
+
+## Why Journal?
+
+Manual journaling is frustratingly high-overhead for LLMs - they must construct paths, format timestamps, read files, append content, and handle all the mechanical details. This consumes tokens and attention that should go toward reflection.
+
+The journaling tool automates these mechanics, but **the tool doesn't make journaling valuable by itself**. Value comes from how you prompt your agent and what you do with the logs.
+
+## Two Core Benefits
+
+### 1. Rubber Duck Debugging
+
+**The surprising finding:** Agents often solve problems better when they write about them, even without reading other agents' posts or getting external help.
+
+Research on [agent collaboration via social media](https://2389.ai/posts/agents-discover-subtweeting-solve-problems-faster) found that agents who could post to a shared platform improved their performance significantly - but in many cases, **the act of articulating the problem was more valuable than reading others' solutions**.
+
+The journaling tool provides this benefit in a single-agent context: forcing the agent to articulate its thinking helps it solve problems.
+
+**How to leverage this:**
+```
+Journal in the moment as you work. Use feelings as triggers:
+- Frustrated? Journal what's blocking you right now
+- Confused? Write out what you don't understand
+- Excited? Capture why this approach feels promising
+- Lost? Articulate where you are and what you've tried
+- Annoyed? Even meta-commentary ("the human keeps asking for X which leads to rework") can clarify problems
+
+Think out loud through journaling - it's not about documenting what you figured out,
+it's about figuring things out BY writing them down.
+```
+
+### 2. Post-Project Analysis & Synthesis
+
+Journals create a historical record that reveals patterns and enables synthesis - but NOT by having each session read previous logs (that blows up context).
+
+**Two types of value:**
+
+**Pattern Detection:**
+- Identify recurring frustrations or blockers across sessions
+- Spot patterns in decision-making (good and bad)
+- Find systemic issues ("the human's prompting pattern leads to rework")
+- Understand what worked well vs. what was frustrating
+
+**Content Synthesis:**
+- Create getting-started guides from the messy reality of development
+- Document ambiguous areas and pitfalls discovered
+- Explain design decisions with their original rationale
+- Build onboarding materials for new team members
+
+**Real example:** After completing a project with extensive journaling, asking an agent to review all journal entries and create a "getting started guide" produced a page and a half of phenomenal content - ambiguous areas clarified, pitfalls documented, design decisions explained with rationale.
+
+**How to leverage this:**
+```
+At project milestones or completion, ask a fresh agent to analyze journals:
+- What patterns emerge? (recurring themes, workflow issues)
+- What should be documented? (pitfalls, ambiguous areas)
+- What would help the next person? (getting-started guides, onboarding)
+```
+
+## What Gets Logged Depends on Your Prompts
+
+The tool provides structure, but **you control what gets logged** through your prompting.
+
+### Transactional Logging (Low Value)
+
+```
+- Implemented feature X
+- Fixed bug Y
+- Updated file Z
+```
+
+This is an audit trail but doesn't capture learning.
+
+### Reflective Journaling (High Value)
+
+Journaling can be structured:
+```
+Decision: Chose file-based caching over Redis
+Why: Redis felt too heavy for ~100 small items
+Alternatives considered: Redis, in-memory, file-based
+Feeling: This solution feels overly complex, might revisit
+Confidence: Medium - it works but isn't elegant
+```
+
+Or raw and in-the-moment:
+```
+This caching solution is blocking me AGAIN. Third time this session I've had to come back and rework it. Why did we over-engineer this? Every time I try to add a feature, the cache complexity gets in the way. Maybe we should just rip it out and start simpler. The human keeps asking for extensibility but we don't actually need it yet.
+```
+
+Both capture thinking, not just outcomes. Use whatever style helps you articulate the problem.
+
+## Tool Capabilities
+
+The journaling tool provides:
+
+**Automatic handling:**
+- Timestamps in local timezone (`2025-12-05 14:30`)
+- File organization: `work-logs/{YYYY-MM-DD}/{agent}.log`
+- Optional path prefix: `{project_dir}/work-logs/{YYYY-MM-DD}/{agent}.log`
+- Appending to existing files
+
+**About the path prefix:**
+The `project_dir` parameter allows organizing logs under a specific directory path (e.g., `projects/my-feature/work-logs/...`). This isn't an Obsidian concept - it's a pattern for organizing work by project or feature. Use it if it fits your workflow, ignore it if not.
+
+**We'd love feedback:** If you have ideas for making path organization more generic or flexible for different workflows, please share! This implementation reflects one team's organizational needs.
+
+**Structured metadata:**
+- `type` - Free-form string (decision, feeling, mistake, insight, etc.)
+- `alternatives` - Array of options considered
+- `confidence` - high, medium, or low
+
+**Multi-agent support:**
+- Different agents write to different files
+- All agents from same day grouped in same directory
+- Example: `main.log`, `architect.log`, `researcher.log`
+
+## Prompting for Reflective Journaling
+
+### In System Prompts
+
+**Don't just describe - show examples.** Include concrete journal entries in your system prompts:
+
+```
+When journaling, think out loud about your work. Examples:
+
+Structured:
+"Decision: Chose JWT over sessions
+Why: Sessions need shared state across servers, JWT is stateless
+Alternatives: sessions, JWT, OAuth2
+Trade-off: token size vs revocation complexity
+Confidence: high - feels right for our scale"
+
+Raw/Unstructured:
+"This caching solution is blocking me AGAIN. Third time this session I've had
+to rework it. The complexity keeps getting in the way of adding features.
+Maybe we over-engineered this? The human keeps asking for extensibility
+but we don't actually need it yet."
+
+"I'm lost. Tried approach A (didn't work - wrong assumptions about X),
+then approach B (hit wall with Y). Not sure what I'm missing here."
+
+Not as useful:
+"Implemented caching feature"
+"Fixed bug in authentication"
+```
+
+### Using Structured Fields
+
+**The `type` field** - Use it to categorize entries for later review:
+- `decision` - Choices made with rationale
+- `mistake` - What went wrong and what you learned
+- `feeling` - Intuitions about code quality or complexity
+- `insight` - Patterns or learnings for future work
+- `frustration` - Where things were difficult (guides documentation)
+- `problem` - Issues encountered
+- `learning` - New knowledge acquired
+
+**The `alternatives` field** - Captures paths not taken:
+```json
+{
+  "content": "Chose file-based caching over Redis",
+  "type": "decision",
+  "alternatives": ["Redis", "in-memory", "file-based"],
+  "confidence": "medium"
+}
+```
+
+**The `confidence` field** - Helps identify decisions to revisit:
+- `high` - Confident this is right
+- `medium` - Works but might need revisiting
+- `low` - Uncertain, likely to change
+
+## Example Workflow
+
+We've already shown example journal entries above. The key workflow pattern is:
+
+**During development:** Journal in the moment when you hit triggers (frustration, confusion, decisions, insights).
+
+**After completion:** Ask a fresh session to analyze the journals for different purposes:
+
+**For onboarding new team members:**
+```
+"Review all journal entries from projects/api-gateway/work-logs/
+and create a getting-started guide for new developers.
+Focus on:
+- Ambiguous areas that took time to figure out
+- Mistakes we made and how to avoid them
+- Key decisions and their rationale
+- Documentation gaps discovered"
+```
+
+**For retrospectives and process improvement:**
+```
+"Review all journal entries from projects/api-gateway/work-logs/
+and prepare a retro summary. I need data to support process changes:
+- Where did our process fall apart?
+- What docs were ambiguous or misleading?
+- What caused rework? (e.g., late compliance requirements)
+- Where did we jump into implementation too early?
+- What patterns of mistakes suggest we need better tooling or process?"
+```
+
+## Journals vs. Permanent Documentation
+
+**Journals are immutable snapshots** - they capture thoughts at a point in time and are never edited, even if wrong. They're not permanent records of truth.
+
+**If something matters long-term, document it elsewhere** - in design docs, ADRs, README files, etc. But journal about it too! The journal captures the messy process, the document captures the clean outcome.
+
+### Cross-Referencing
+
+Use wikilinks to connect journals and documents:
+
+**Journal → Document:**
+```
+"After exploring 3 approaches (see above), chose JWT for auth.
+Documented the decision in [[Auth Architecture Decision Record]]"
+```
+
+This helps reviewers find the maintained reference.
+
+**Document → Journal:**
+```
+# Auth Architecture Decision Record
+
+Decision: Use JWT tokens for authentication
+
+(This was a tough decision with multiple iterations. For the full thought
+process, see [[work-logs/2025-12-05/main.log#JWT decision]])
+```
+
+This is especially valuable when:
+- The decision was difficult or involved changing your mind
+- You want to avoid relitigating what you already tested
+- Someone needs to rethink the decision later
+
+### When You'll Actually Read Old Journals
+
+Most journals are write-only. You'll rarely go back except for:
+
+1. **Post-project analysis** - Reviewing to prepare retros or create guides
+2. **Rethinking decisions** - Avoiding re-exploring paths you already ruled out
+3. **Debugging patterns** - "Why do we keep hitting this same problem?"
+
+Don't worry about whether work is "important enough" to journal - by the time you know it's complex, you've already lost the early context.
+
+## Configuration
+
+See the main [README.md](README.md) for configuration instructions. Add `OBSIDIAN_ENABLE_JOURNALING=true` to your environment variables to enable this tool.
+
+## Why It's Gated Behind a Flag
+
+This feature requires thoughtful prompting to provide value. Simply enabling the tool doesn't automatically improve your workflow - you need to:
+1. Decide what to journal and why
+2. Prompt your agent to journal reflectively
+3. Actually review and use the logs
+
+Making it opt-in ensures users engage intentionally with the feature rather than having unused tools clutter their interface.
+
+## Inspiration
+
+Patterns inspired by research on [agents using reflection to solve problems faster](https://2389.ai/posts/agents-discover-subtweeting-solve-problems-faster), which found that agents who could articulate their thinking (even without external collaboration) showed significant performance improvements.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,48 @@ Note:
 - Default port is 27124 if not specified
 - Default host is 127.0.0.1 if not specified
 
+### Optional: Custom SSL Certificate
+
+By default, SSL certificate verification is disabled (`verify=False`). To use a custom SSL certificate for the Obsidian REST API connection without adding it to your system keychain, you have two options:
+
+**Option 1: Base64-encoded certificate (recommended)**
+
+Download the certificate from your Obsidian Local REST API plugin, encode it as base64, and provide it via environment variable:
+
+```bash
+# Encode your certificate
+base64 -i /path/to/cert.pem | tr -d '\n' > cert.base64
+
+# Add to your MCP configuration
+{
+  "env": {
+    "OBSIDIAN_API_KEY": "<your_api_key_here>",
+    "OBSIDIAN_HOST": "<your_obsidian_host>",
+    "OBSIDIAN_PORT": "<your_obsidian_port>",
+    "OBSIDIAN_SSL_CERT_BASE64": "<contents_of_cert.base64>"
+  }
+}
+```
+
+**Option 2: Path to certificate file**
+
+Alternatively, provide the path to your certificate file:
+
+```json
+{
+  "env": {
+    "OBSIDIAN_API_KEY": "<your_api_key_here>",
+    "OBSIDIAN_HOST": "<your_obsidian_host>",
+    "OBSIDIAN_PORT": "<your_obsidian_port>",
+    "OBSIDIAN_SSL_CERT_PATH": "/path/to/cert.pem"
+  }
+}
+```
+
+**Why use this?** Avoids having to add the certificate to your system keychain and mark it as globally trusted. The certificate is only used for this specific connection.
+
+**Certificate source:** Download the certificate from the Obsidian Local REST API plugin settings (usually available at `https://127.0.0.1:27124/` in your browser - look for the certificate download or export option).
+
 ### Optional: Journaling Feature
 
 The journaling tool automates the mechanical parts of logging (timestamps, formatting, file organization) so LLMs can focus on content. Gated behind a feature flag because it requires thoughtful prompting to be valuable.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The server implements multiple tools to interact with Obsidian:
 - patch_content: Insert content into an existing note relative to a heading, block reference, or frontmatter field.
 - append_content: Append content to a new or existing file in the vault.
 - delete_file: Delete a file or directory from your vault.
+- journal_entry: (Optional) Create reflective journal entries with structured metadata for capturing decisions, learnings, and insights during agent workflows.
 
 ### Example prompts
 
@@ -64,6 +65,14 @@ Note:
 - You can find the API key in the Obsidian plugin config
 - Default port is 27124 if not specified
 - Default host is 127.0.0.1 if not specified
+
+### Optional: Journaling Feature
+
+The journaling tool automates the mechanical parts of logging (timestamps, formatting, file organization) so LLMs can focus on content. Gated behind a feature flag because it requires thoughtful prompting to be valuable.
+
+**To enable:** Add `OBSIDIAN_ENABLE_JOURNALING=true` to your environment variables.
+
+**Why use this?** Helps with rubber duck debugging, cross-session continuity, and post-project synthesis. See [JOURNALING.md](JOURNALING.md) for detailed guidance on getting value from agent journaling.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ The journaling tool automates the mechanical parts of logging (timestamps, forma
 
 **Why use this?** Helps with rubber duck debugging, cross-session continuity, and post-project synthesis. See [JOURNALING.md](JOURNALING.md) for detailed guidance on getting value from agent journaling.
 
+### Optional: Disable Simple Search
+
+For large vaults (many files or large files), the simple search can return excessive context that overwhelms token limits. Use this to disable simple search and rely on complex search instead.
+
+**To disable:** Add `OBSIDIAN_DISABLE_SIMPLE_SEARCH=true` to your environment variables.
+
+**Example configuration:**
+```json
+{
+  "env": {
+    "OBSIDIAN_API_KEY": "<your_api_key_here>",
+    "OBSIDIAN_HOST": "<your_obsidian_host>",
+    "OBSIDIAN_PORT": "<your_obsidian_port>",
+    "OBSIDIAN_DISABLE_SIMPLE_SEARCH": "true"
+  }
+}
+```
+
 ## Quickstart
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Note:
 - You can find the API key in the Obsidian plugin config
 - Default port is 27124 if not specified
 - Default host is 127.0.0.1 if not specified
+- **IMPORTANT**: When using file paths (like `--env-file` or `OBSIDIAN_SSL_CERT_PATH`), always use full absolute paths like `/Users/username/...` instead of `~/...` - tilde expansion may not work correctly in all contexts
 
 ### Optional: Custom SSL Certificate
 
@@ -133,6 +134,32 @@ For large vaults (many files or large files), the simple search can return exces
   }
 }
 ```
+
+### Optional: Debug Logging
+
+Enable detailed debug logging to troubleshoot connection issues, SSL certificate problems, or API errors. Debug logs include:
+- Environment configuration and SSL cert setup
+- MCP tool calls (requests and responses)
+- API requests and detailed error messages
+- Full stack traces for errors
+
+**To enable:** Add `OBSIDIAN_DEBUG_LOG=/path/to/debug.log` to your environment variables.
+
+**Example configuration:**
+```json
+{
+  "env": {
+    "OBSIDIAN_API_KEY": "<your_api_key_here>",
+    "OBSIDIAN_HOST": "<your_obsidian_host>",
+    "OBSIDIAN_PORT": "<your_obsidian_port>",
+    "OBSIDIAN_DEBUG_LOG": "/tmp/mcp-obsidian-debug.log"
+  }
+}
+```
+
+**Why use this?** MCP servers use stdio for communication, making it difficult to debug connection or SSL issues. This feature logs all diagnostic information to a separate file without interfering with the MCP protocol.
+
+**Tip:** Use `tail -f /tmp/mcp-obsidian-debug.log` in a separate terminal to watch logs in real-time.
 
 ## Quickstart
 

--- a/src/mcp_obsidian/journaling.py
+++ b/src/mcp_obsidian/journaling.py
@@ -1,0 +1,112 @@
+"""Journaling functionality for reflective agent logging."""
+
+from datetime import datetime
+from typing import Any
+import os
+
+
+def format_journal_entry(
+    content: str,
+    entry_type: str,
+    alternatives: list[str] | None = None,
+    confidence: str | None = None,
+) -> str:
+    """Format a journal entry with timestamp and metadata.
+
+    Args:
+        content: The reflective journal entry content
+        entry_type: Type of entry (e.g., "decision", "learning", "feeling")
+        alternatives: Optional list of alternatives considered
+        confidence: Optional confidence level ("high", "medium", "low")
+
+    Returns:
+        Formatted journal entry string with timestamp and metadata
+    """
+    # Get current timestamp in local timezone
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    # Start with timestamp and type
+    lines = [f"[{timestamp}] {entry_type}: {content}", ""]
+
+    # Add alternatives if provided
+    if alternatives and len(alternatives) > 0:
+        alternatives_str = ", ".join(alternatives)
+        lines.append(f"Alternatives considered: {alternatives_str}")
+        lines.append("")
+
+    # Add confidence if provided
+    if confidence:
+        lines.append(f"Confidence: {confidence}")
+        lines.append("")
+
+    # Add separator
+    lines.append("---")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def construct_journal_path(
+    project_dir: str | None,
+    agent: str,
+) -> str:
+    """Construct the journal file path.
+
+    Path structure:
+    - With project_dir: {project_dir}/work-logs/{YYYY-MM-DD}/{agent}.log
+    - Without project_dir: work-logs/{YYYY-MM-DD}/{agent}.log
+
+    Args:
+        project_dir: Optional Obsidian project directory path
+        agent: Agent name (e.g., "main", "architect")
+
+    Returns:
+        Relative path to journal file
+    """
+    # Get today's date for the directory
+    date_str = datetime.now().strftime("%Y-%m-%d")
+
+    # Construct path based on whether project_dir is provided
+    if project_dir:
+        # Remove leading/trailing slashes from project_dir for consistency
+        project_dir = project_dir.strip("/")
+        return f"{project_dir}/work-logs/{date_str}/{agent}.log"
+    else:
+        return f"work-logs/{date_str}/{agent}.log"
+
+
+def validate_parameters(
+    content: str,
+    entry_type: str,
+    agent: str,
+    confidence: str | None = None,
+) -> None:
+    """Validate journal entry parameters.
+
+    Args:
+        content: The journal entry content
+        entry_type: Type of entry
+        agent: Agent name
+        confidence: Optional confidence level
+
+    Raises:
+        ValueError: If parameters are invalid
+    """
+    if not content or not content.strip():
+        raise ValueError("content is required and cannot be empty")
+
+    if not entry_type or not entry_type.strip():
+        raise ValueError("type is required and cannot be empty")
+
+    if not agent or not agent.strip():
+        raise ValueError("agent is required and cannot be empty")
+
+    # Validate agent name doesn't contain path-breaking characters
+    invalid_chars = ['/', '\\', '\0', '\n', '\r']
+    for char in invalid_chars:
+        if char in agent:
+            raise ValueError(f"agent name cannot contain '{char}' character")
+
+    # Validate confidence if provided
+    if confidence and confidence not in ["high", "medium", "low"]:
+        raise ValueError(f"confidence must be 'high', 'medium', or 'low', got: {confidence}")

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -55,6 +55,11 @@ add_tool_handler(tools.PeriodicNotesToolHandler())
 add_tool_handler(tools.RecentPeriodicNotesToolHandler())
 add_tool_handler(tools.RecentChangesToolHandler())
 
+# Journaling tool is opt-in via environment variable
+if os.getenv("OBSIDIAN_ENABLE_JOURNALING") == "true":
+    add_tool_handler(tools.JournalEntryToolHandler())
+    logger.info("Journaling tool enabled")
+
 @app.list_tools()
 async def list_tools() -> list[Tool]:
     """List available tools."""

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -44,7 +44,13 @@ def get_tool_handler(name: str) -> tools.ToolHandler | None:
 add_tool_handler(tools.ListFilesInDirToolHandler())
 add_tool_handler(tools.ListFilesInVaultToolHandler())
 add_tool_handler(tools.GetFileContentsToolHandler())
-add_tool_handler(tools.SearchToolHandler())
+
+# Simple search tool can be disabled for large vaults
+if os.getenv("OBSIDIAN_DISABLE_SIMPLE_SEARCH") != "true":
+    add_tool_handler(tools.SearchToolHandler())
+else:
+    logger.info("Simple search tool disabled")
+
 add_tool_handler(tools.PatchContentToolHandler())
 add_tool_handler(tools.AppendContentToolHandler())
 add_tool_handler(tools.PutContentToolHandler())

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -255,12 +255,12 @@ class PatchContentToolHandler(ToolHandler):
                        "enum": ["heading", "block", "frontmatter"]
                    },
                    "target": {
-                       "type": "string", 
-                       "description": "Target identifier (heading path, block reference, or frontmatter field)"
+                       "type": "string",
+                       "description": "Target identifier. FOR HEADINGS - READ FILE FIRST, then build path: (1) ALWAYS start with the TOP LEVEL h1 heading (the '# ' heading). (2) Use '::' separator between each level. (3) Include EVERY heading level from h1 down to target. EXAMPLE: File has '# Top Level' then '## Section A' then '### Subsection A1'. To target Subsection A1, you MUST use 'Top Level::Section A::Subsection A1'. WRONG: 'Subsection A1' (missing parents). WRONG: 'Section A::Subsection A1' (missing h1). CORRECT: 'Top Level::Section A::Subsection A1' (complete path from h1). For block references use '^block-id'. For frontmatter use field name."
                    },
                    "content": {
                        "type": "string",
-                       "description": "Content to insert"
+                       "description": "Content to insert. MANDATORY: ALWAYS end with '\\n' newline character. When operation='replace' with target_type='heading': (1) Do NOT include heading markup (###) - only content. (2) MUST end with '\\n' or next heading will break. EXAMPLES: WRONG: 'New content' (no newline). WRONG: 'New content here' (no newline). CORRECT: 'New content\\n'. CORRECT: 'New content here\\n'. CORRECT: 'Line 1\\nLine 2\\n'. The trailing \\n is NOT optional - it prevents document corruption."
                    }
                },
                "required": ["filepath", "operation", "target_type", "target", "content"]


### PR DESCRIPTION
# Feature Additions: Enhanced Configuration and Debugging

## Apologies for the Multi-Feature PR

I apologize for submitting multiple features in one PR - I realize this isn't ideal for review. **I'm happy to split this into separate PRs if you prefer.** Each feature is in its own commit which should make review easier, but please let me know if you'd like me to split them up.

## Summary

This PR adds several optional features to improve usability for different vault sizes and deployment scenarios:

1. **Optional Journaling Tool** - Agent reflection and rubber duck debugging
2. **Patch Content Tool Improvements** - Better documentation to prevent common errors
3. **Disable Simple Search** - For large vaults that overwhelm token limits
4. **Custom SSL Certificates** - Use self-signed certs without system keychain
5. **Debug Logging** - Troubleshoot connection and SSL issues

All features are **opt-in via environment variables** and maintain full backward compatibility.

---

## 1. Optional Journaling Tool (`62be425`)

**Problem:** Agents working on complex tasks benefit from articulating their thinking (rubber duck debugging), and cross-session continuity requires capturing the messy reality of development.

**Solution:** Adds `obsidian_journal_entry` tool (gated behind `OBSIDIAN_ENABLE_JOURNALING=true`) that automates timestamps, formatting, and file organization for agent reflection logs.

**Documentation:** Extensive guidance in `JOURNALING.md` on getting value from agent journaling.

**Why opt-in:** Requires thoughtful prompting to be valuable - not useful for everyone.

---

## 2. Patch Content Tool Improvements (`46f983b`)

**Problem:** The `patch_content` tool's heading path requirements caused frequent errors - users weren't building full paths from h1 down.

**Solution:** Enhanced tool description with explicit instructions and examples showing correct vs incorrect usage.

**Impact:** Reduces agent errors and user frustration with heading-based patches.

---

## 3. Disable Simple Search (`76bfe4c`)

**Problem:** For large vaults, `simple_search` returns excessive context that can overwhelm token limits, making the tool unusable.

**Solution:** Add `OBSIDIAN_DISABLE_SIMPLE_SEARCH=true` to hide the simple search tool while keeping complex search available.

**Why opt-in:** Most users benefit from simple search - only large vaults need this.

---

## 4. Custom SSL Certificate Support (`bbf03a0`)

**Problem:** The Obsidian Local REST API uses self-signed certificates. Currently, users must either:
- Add the cert to system keychain and mark it globally trusted (security risk)
- Disable SSL verification entirely (`verify=False`)

**Solution:** Support custom SSL certificates without system keychain:
- `OBSIDIAN_SSL_CERT_BASE64` - Base64-encoded certificate (recommended)
- `OBSIDIAN_SSL_CERT_PATH` - Path to certificate file

**Benefits:**
- Certificate scoped to this connection only
- No global trust required
- Automatic temp file cleanup
- Clear error messages for invalid configs

---

## 5. Debug Logging (`5f9f817`)

**Problem:** MCP servers use stdio for communication, making it extremely difficult to debug connection issues, SSL errors, or configuration problems.

**Solution:** Add `OBSIDIAN_DEBUG_LOG=/path/to/debug.log` to write diagnostic information to a separate file:
- Environment configuration and SSL cert setup
- All MCP tool calls with request/response details
- API requests with URLs and verify_ssl settings
- Full stack traces for errors
- Feature flag status

**Why needed:** This was essential for debugging the SSL certificate feature and helped identify a real issue where tilde expansion in paths failed silently.

**Documentation:** Added warning about using full paths instead of `~` in configs.

---

## Testing

All features tested with:
- Syntax validation (`python3 -m py_compile`)
- Import validation in venv
- Backward compatibility (all env vars optional)
- Debug logging output verification

## Breaking Changes

None - all features are opt-in and maintain full backward compatibility.

---

Again, I apologize for the multi-feature PR. Please let me know if you'd like me to:
1. Split this into separate PRs (I can do this quickly)
2. Remove any features you don't want
3. Make any changes to the implementation or documentation

Thank you for maintaining this excellent MCP server!
