### PR TITLE
Fix formatting of default port note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ OBSIDIAN_PORT=your_obsidian_port
 
 Note:
 - You can find the API key in the Obsidian plugin config
-- Default port is 27124 if not specified
 - Default host is 127.0.0.1 if not specified
+- Default port is 27124 if not specified
 
 ## Quickstart
 


### PR DESCRIPTION
this is in the same order as listed above, so folks dont get confused as I did