### PR TITLE
fix: pass OBSIDIAN_PORT and OBSIDIAN_PROTOCOL env vars to client

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -11,9 +11,20 @@ from . import obsidian
 
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+obsidian_port = int(os.getenv("OBSIDIAN_PORT", "27124"))
+obsidian_protocol = os.getenv("OBSIDIAN_PROTOCOL", "https")
 
 if api_key == "":
     raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+
+def _make_client():
+    """Create an Obsidian client with connection settings from environment."""
+    return obsidian.Obsidian(
+        api_key=api_key,
+        host=obsidian_host,
+        port=obsidian_port,
+        protocol=obsidian_protocol,
+    )
 
 TOOL_LIST_FILES_IN_VAULT = "obsidian_list_files_in_vault"
 TOOL_LIST_FILES_IN_DIR = "obsidian_list_files_in_dir"
@@ -44,7 +55,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
 
         files = api.list_files_in_vault()
 
@@ -80,7 +91,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         if "dirpath" not in args:
             raise RuntimeError("dirpath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
 
         files = api.list_files_in_dir(args["dirpath"])
 
@@ -116,7 +127,7 @@ class GetFileContentsToolHandler(ToolHandler):
         if "filepath" not in args:
             raise RuntimeError("filepath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
 
         content = api.get_file_contents(args["filepath"])
 
@@ -159,7 +170,7 @@ class SearchToolHandler(ToolHandler):
 
         context_length = args.get("context_length", 100)
         
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         results = api.search(args["query"], context_length)
         
         formatted_results = []
@@ -218,7 +229,7 @@ class AppendContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.append_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -271,7 +282,7 @@ class PatchContentToolHandler(ToolHandler):
        if not all(k in args for k in ["filepath", "operation", "target_type", "target", "content"]):
            raise RuntimeError("filepath, operation, target_type, target and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.patch_content(
            args.get("filepath", ""),
            args.get("operation", ""),
@@ -316,7 +327,7 @@ class PutContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.put_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -360,7 +371,7 @@ class DeleteFileToolHandler(ToolHandler):
        if not args.get("confirm", False):
            raise RuntimeError("confirm must be set to true to delete a file")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.delete_file(args["filepath"])
 
        return [
@@ -424,7 +435,7 @@ class ComplexSearchToolHandler(ToolHandler):
        if "query" not in args:
            raise RuntimeError("query argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        results = api.search_json(args.get("query", ""))
 
        return [
@@ -463,7 +474,7 @@ class BatchGetFileContentsToolHandler(ToolHandler):
         if "filepaths" not in args:
             raise RuntimeError("filepaths argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         content = api.get_batch_file_contents(args["filepaths"])
 
         return [
@@ -514,7 +525,7 @@ class PeriodicNotesToolHandler(ToolHandler):
         if type not in valid_types:
             raise RuntimeError(f"Invalid type: {type}. Must be one of: {', '.join(valid_types)}")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         content = api.get_periodic_note(period,type)
 
         return [
@@ -574,7 +585,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         if not isinstance(include_content, bool):
             raise RuntimeError(f"Invalid include_content: {include_content}. Must be a boolean")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         results = api.get_recent_periodic_notes(period, limit, include_content)
 
         return [
@@ -621,7 +632,7 @@ class RecentChangesToolHandler(ToolHandler):
         if not isinstance(days, int) or days < 1:
             raise RuntimeError(f"Invalid days: {days}. Must be a positive integer")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         results = api.get_recent_changes(limit, days)
 
         return [


### PR DESCRIPTION
## Summary

`tools.py` reads `OBSIDIAN_HOST` from the environment (line 13) and passes it to the `Obsidian()` constructor, but `OBSIDIAN_PORT` and `OBSIDIAN_PROTOCOL` are never read or passed. This causes the client to always connect on port 27124 with HTTPS regardless of environment configuration, breaking Docker, remote, and non-default-port setups.

## Changes

- Read `OBSIDIAN_PORT` and `OBSIDIAN_PROTOCOL` environment variables in `tools.py`, following the same pattern as the existing `OBSIDIAN_HOST` read
- Introduce a `_make_client()` factory function that passes all three connection settings (`host`, `port`, `protocol`) to the `Obsidian()` constructor
- Replace all 13 direct `Obsidian()` constructor calls with `_make_client()`

## Why a factory function?

There are 13 places in `tools.py` that create an `Obsidian` client. Rather than updating each call site to pass three additional parameters, a small factory keeps things DRY and makes future connection parameter changes a one-line fix.

## Backward compatibility

Fully backward-compatible. Default values match current behavior:
- `OBSIDIAN_HOST` → `127.0.0.1`
- `OBSIDIAN_PORT` → `27124`
- `OBSIDIAN_PROTOCOL` → `https`

Existing setups that don't set these env vars will behave identically.

Fixes #111, Fixes #112