### PR TITLE
docs: clarify that patch_content heading targets require fully qualified :: path

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -235,7 +235,7 @@ class PatchContentToolHandler(ToolHandler):
    def get_tool_description(self):
        return Tool(
            name=self.name,
-           description="Insert content into an existing note relative to a heading, block reference, or frontmatter field.",
+           description="Insert content into an existing note relative to a heading, block reference, or frontmatter field.\n\nIMPORTANT: For heading targets, you MUST use the fully qualified heading path from the document's root heading using '::' as a delimiter. For example, if the file contains '# My Document' with '## Section A' underneath, use target='My Document::Section A', NOT just 'Section A'. Only top-level (H1) headings can be referenced by name alone. Using a bare sub-heading name will result in error 40080 (invalid-target).",
            inputSchema={
                "type": "object",
                "properties": {
@@ -256,7 +256,7 @@ class PatchContentToolHandler(ToolHandler):
                    },
                    "target": {
                        "type": "string", 
-                       "description": "Target identifier (heading path, block reference, or frontmatter field)"
+                       "description": "Target identifier. For headings: use '::'-delimited path from the root heading (e.g. 'Root Heading::Sub Heading::Sub Sub Heading'). Only top-level H1 headings can be targeted by name alone. For blocks: the block reference ID (without ^). For frontmatter: the field name."
                    },
                    "content": {
                        "type": "string",


### PR DESCRIPTION
## Problem

The `patch_content` tool's description for heading targets does not explain that the `target` parameter requires a **fully qualified heading path** from the document root using `::` as a delimiter. This causes LLMs (Claude, etc.) to consistently pass bare sub-heading names like `"Progress Log"` when the actual required value is `"My Document::Progress Log"`.

The result is:
- **Error 40080** (`invalid-target`) on every attempt to patch a sub-heading
- The Obsidian REST API plugin can **hang indefinitely** after a failed PATCH, requiring an Obsidian restart (see #3)
- LLMs fall into retry loops trying different heading formats, wasting tokens and user patience

## Root Cause

The underlying Obsidian Local REST API's `findHeadingBoundary` function walks the document's heading tree hierarchically. When `target="Progress Log"` is sent, it looks for a **top-level** `# Progress Log`. But if `## Progress Log` is a child of `# My Document`, it can't find it and returns `invalid-target`.

The tool descriptions in `tools.py` gave no indication of this requirement:
- Tool description: `"Insert content into an existing note relative to a heading, block reference, or frontmatter field."`
- Target parameter: `"Target identifier (heading path, block reference, or frontmatter field)"`

Neither mentions the `::` delimiter, the need for fully qualified paths, or the consequence of getting it wrong.

## Fix

Updated both descriptions with clear guidance:
- The **tool-level description** now explains the fully qualified path requirement with an example
- The **target parameter description** now documents the `::` delimiter syntax for headings, and clarifies the block reference and frontmatter formats

## Testing

Manually verified against a live Obsidian vault with nested headings:

| Target value | Result |
|---|---|
| `My Document` (H1) | Works |
| `Progress Log` (bare H2) | Error 40080 |
| `My Document::Progress Log` (qualified) | Works |

Relates to #24, #3
