### PR TITLE
fix: patch_content - heading path format, timeout, UTF-8 encoding

### DIFF
--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -22,7 +22,7 @@ class Obsidian():
         self.host = host
         self.port = port
         self.verify_ssl = verify_ssl
-        self.timeout = (3, 6)
+        self.timeout = (5, 30)
 
     def get_base_url(self) -> str:
         return f'{self.protocol}://{self.host}:{self.port}'
@@ -120,7 +120,7 @@ class Obsidian():
             response = requests.post(
                 url, 
                 headers=self._get_headers() | {'Content-Type': 'text/markdown'}, 
-                data=content,
+                data=content.encode('utf-8'),
                 verify=self.verify_ssl,
                 timeout=self.timeout
             )

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -140,7 +140,7 @@ class Obsidian():
         }
         
         def call_fn():
-            response = requests.patch(url, headers=headers, data=content, verify=self.verify_ssl, timeout=self.timeout)
+            response = requests.patch(url, headers=headers, data=content.encode('utf-8'), verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             return None
 

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -235,7 +235,7 @@ class PatchContentToolHandler(ToolHandler):
    def get_tool_description(self):
        return Tool(
            name=self.name,
-           description="Insert content into an existing note relative to a heading, block reference, or frontmatter field.",
+           description="Insert content into an existing note relative to a heading, block reference, or frontmatter field. IMPORTANT: For headings, you must provide the FULL heading path using '::' as separator. Example: if your note has '# Main' with '## Sub' underneath, the target must be 'Main::Sub', not just 'Sub'. For top-level headings, just use the heading text without the '#' symbols.",
            inputSchema={
                "type": "object",
                "properties": {
@@ -256,7 +256,7 @@ class PatchContentToolHandler(ToolHandler):
                    },
                    "target": {
                        "type": "string", 
-                       "description": "Target identifier (heading path, block reference, or frontmatter field)"
+                      "description": "Target identifier. For headings: use full path with '::' delimiter (e.g. 'Parent Heading::Child Heading'). For top-level headings use just the name (e.g. 'My Section'). For blocks: use the block reference ID. For frontmatter: use the field name."
                    },
                    "content": {
                        "type": "string",


### PR DESCRIPTION
Fixes #3, #9, #24

## Problem
patch_content consistently fails with invalid-target error and causes the Obsidian REST API plugin to hang.

## Root Causes
1. **Heading path format**: REST API v3 requires full heading path with :: delimiter (e.g. Parent::Child), but the tool description did not document this. LLMs sent just the heading name, which the API could not find.
2. **Timeout too short**: (3, 6) seconds was not enough. When the REST API fails to find the target, it hangs instead of returning an error.
3. **Missing UTF-8 encoding**: Content body sent without explicit UTF-8 encoding, causing issues with non-ASCII characters.

## Changes
- **obsidian.py**: Timeout (3, 6) -> (5, 30)
- **obsidian.py**: data=content -> data=content.encode('utf-8')
- **tools.py**: Updated patch_content tool and target field descriptions to document required heading path format

## Testing
Tested with headings containing: plain text, umlauts, parentheses, em-dashes — all pass after fix.