### PR TITLE
feat: add obsidian_search_smart tool for semantic vault search

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The server implements multiple tools to interact with Obsidian:
 - list_files_in_dir: Lists all files and directories in a specific Obsidian directory
 - get_file_contents: Return the content of a single file in your vault.
 - search: Search for documents matching a specified text query across all files in the vault
+- search_smart: Semantic (vector) search across the vault using Smart Connections embeddings. Requires the `MCP Tools` and `Smart Connections` Obsidian community plugins in addition to `Local REST API`.
 - patch_content: Insert content into an existing note relative to a heading, block reference, or frontmatter field.
 - append_content: Append content to a new or existing file in the vault.
 - delete_file: Delete a file or directory from your vault.

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -1,3 +1,4 @@
+import json
 import requests
 import urllib.parse
 import os
@@ -43,6 +44,47 @@ class Obsidian():
             raise Exception(f"Error {code}: {message}")
         except requests.exceptions.RequestException as e:
             raise Exception(f"Request failed: {str(e)}")
+
+    def search_smart(self, query: str, filter: dict | None = None) -> Any:
+        """Semantic (vector) search via the mcp-tools plugin's /search/smart endpoint.
+
+        Requires Obsidian plugins: Local REST API + mcp-tools + Smart Connections.
+
+        The endpoint validator uses arktype's type("string.json.parse"), which means the
+        body must arrive as a RAW STRING that the server itself JSON-parses. Sending it
+        with Content-Type: application/json would let Express auto-parse it into an
+        object first and fail validation with "must be a string (was an object)".
+        """
+        url = f"{self.get_base_url()}/search/smart"
+
+        body: dict = {"query": query}
+        if filter:
+            body["filter"] = filter
+
+        def call_fn():
+            headers = self._get_headers()
+            headers["Content-Type"] = "text/plain"
+            response = requests.post(
+                url,
+                headers=headers,
+                data=json.dumps(body),
+                verify=self.verify_ssl,
+                timeout=self.timeout,
+            )
+            if response.status_code == 404:
+                raise Exception(
+                    "/search/smart not found — the mcp-tools Obsidian plugin is not "
+                    "installed. Install 'MCP Tools' + 'Smart Connections' plugins."
+                )
+            if response.status_code == 503:
+                raise Exception(
+                    "Smart Connections plugin is not available in Obsidian. Install "
+                    "and enable it to use semantic search."
+                )
+            response.raise_for_status()
+            return response.json()
+
+        return self._safe_call(call_fn)
 
     def list_files_in_vault(self) -> Any:
         url = f"{self.get_base_url()}/vault/"

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -54,6 +54,7 @@ add_tool_handler(tools.BatchGetFileContentsToolHandler())
 add_tool_handler(tools.PeriodicNotesToolHandler())
 add_tool_handler(tools.RecentPeriodicNotesToolHandler())
 add_tool_handler(tools.RecentChangesToolHandler())
+add_tool_handler(tools.SmartSearchToolHandler())
 
 @app.list_tools()
 async def list_tools() -> list[Tool]:

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -584,6 +584,71 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
             )
         ]
         
+class SmartSearchToolHandler(ToolHandler):
+    def __init__(self):
+        super().__init__("obsidian_search_smart")
+
+    def get_tool_description(self):
+        return Tool(
+            name=self.name,
+            description=(
+                "Semantic (vector) search across your Obsidian vault using Smart "
+                "Connections embeddings. Ranks notes by semantic similarity rather "
+                "than keyword match — use this when you want meaning-based retrieval "
+                "('how does authentication flow end-to-end') rather than literal "
+                "string matching. Requires the 'MCP Tools' and 'Smart Connections' "
+                "Obsidian plugins to be installed and enabled."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language query. The longer / more specific the phrase, the better the embedding match.",
+                        "minLength": 1,
+                    },
+                    "folders": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": 'Optional: restrict results to these folder prefixes (e.g. ["Labs/Architecture"]).',
+                    },
+                    "exclude_folders": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": 'Optional: exclude these folder prefixes (e.g. ["Archive", "Private"]).',
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Optional: maximum number of results to return.",
+                        "minimum": 1,
+                    },
+                },
+                "required": ["query"],
+            },
+        )
+
+    def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
+        if "query" not in args:
+            raise RuntimeError("query argument missing in arguments")
+
+        filter_: dict = {}
+        if "folders" in args and args["folders"]:
+            filter_["folders"] = args["folders"]
+        if "exclude_folders" in args and args["exclude_folders"]:
+            filter_["excludeFolders"] = args["exclude_folders"]
+        if "limit" in args and args["limit"]:
+            filter_["limit"] = args["limit"]
+
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        results = api.search_smart(args["query"], filter_ or None)
+
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(results, indent=2),
+            )
+        ]
+
 class RecentChangesToolHandler(ToolHandler):
     def __init__(self):
         super().__init__("obsidian_get_recent_changes")


### PR DESCRIPTION
## What

Adds `obsidian_search_smart`, a new tool wrapping the `/search/smart` endpoint from Jack Steam's [`obsidian-mcp-tools`](https://github.com/jacksteamdev/obsidian-mcp-tools) community plugin. This exposes **semantic (vector-based) search** over the vault, complementing the existing keyword `obsidian_simple_search` and JsonLogic `obsidian_complex_search`.

## Why

Keyword search is surprisingly limiting for LLM workflows — asking "how does authentication flow end-to-end" with `simple_search` matches only the literal word "authentication". With Smart Connections embeddings, the same query retrieves the right notes by meaning. This tool gives MCP clients access to that semantic layer without needing a second MCP server.

## Schema

```json
{
  "query": "natural-language phrase",
  "folders": ["optional", "folder", "prefixes"],
  "exclude_folders": ["optional", "exclusions"],
  "limit": 10
}
```

Filter fields map 1:1 to the upstream plugin's `SearchParameters` schema.

## Dependencies (user-side)

- `obsidian-local-rest-api` (already required by this project)
- `obsidian-mcp-tools` (provides `/search/smart`)
- `smart-connections` (provides the embeddings)

## Error handling

- `404` from the endpoint → actionable "install `MCP Tools` plugin" error
- `503` → "install / enable `Smart Connections`"

## Implementation note — the arktype validator quirk (important for future maintenance)

The `/search/smart` endpoint validates its body with `type("string.json.parse").to(searchRequest)` (arktype). That means `req.body` must arrive as a **raw string** which the server itself JSON-parses. Sending `Content-Type: application/json` lets Express pre-parse into an object and the arktype validator rejects with `"must be a string (was an object)"`. The client therefore posts with `Content-Type: text/plain` and an already-serialized body. The docstring on `search_smart()` captures this reasoning so it doesn't become tribal knowledge.

## Testing

Verified end-to-end against a real Obsidian vault with all three plugins installed. Queries return correctly-scored results; `folders` / `exclude_folders` / `limit` all function as expected (subject to Smart Connections' background index being up to date).

No new Python dependencies.

## Files changed

- `src/mcp_obsidian/obsidian.py` — new `search_smart()` client method (+`import json`)
- `src/mcp_obsidian/tools.py` — new `SmartSearchToolHandler` class
- `src/mcp_obsidian/server.py` — registers the handler
- `README.md` — new bullet under the Tools list documenting the plugin requirements