### PR TITLE
fix: pass OBSIDIAN_PROTOCOL and OBSIDIAN_PORT env vars to Obsidian client

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -10,7 +10,9 @@ import os
 from . import obsidian
 
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
+obsidian_protocol = os.getenv("OBSIDIAN_PROTOCOL", "https").lower()
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+obsidian_port = int(os.getenv("OBSIDIAN_PORT", "27124"))
 
 if api_key == "":
     raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
@@ -44,7 +46,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
 
         files = api.list_files_in_vault()
 
@@ -80,7 +82,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         if "dirpath" not in args:
             raise RuntimeError("dirpath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
 
         files = api.list_files_in_dir(args["dirpath"])
 
@@ -116,7 +118,7 @@ class GetFileContentsToolHandler(ToolHandler):
         if "filepath" not in args:
             raise RuntimeError("filepath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
 
         content = api.get_file_contents(args["filepath"])
 
@@ -159,7 +161,7 @@ class SearchToolHandler(ToolHandler):
 
         context_length = args.get("context_length", 100)
         
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
         results = api.search(args["query"], context_length)
         
         formatted_results = []
@@ -218,7 +220,7 @@ class AppendContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
        api.append_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -271,7 +273,7 @@ class PatchContentToolHandler(ToolHandler):
        if not all(k in args for k in ["filepath", "operation", "target_type", "target", "content"]):
            raise RuntimeError("filepath, operation, target_type, target and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
        api.patch_content(
            args.get("filepath", ""),
            args.get("operation", ""),
@@ -316,7 +318,7 @@ class PutContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
        api.put_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -360,7 +362,7 @@ class DeleteFileToolHandler(ToolHandler):
        if not args.get("confirm", False):
            raise RuntimeError("confirm must be set to true to delete a file")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
        api.delete_file(args["filepath"])
 
        return [
@@ -424,7 +426,7 @@ class ComplexSearchToolHandler(ToolHandler):
        if "query" not in args:
            raise RuntimeError("query argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
        results = api.search_json(args.get("query", ""))
 
        return [
@@ -463,7 +465,7 @@ class BatchGetFileContentsToolHandler(ToolHandler):
         if "filepaths" not in args:
             raise RuntimeError("filepaths argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
         content = api.get_batch_file_contents(args["filepaths"])
 
         return [
@@ -514,7 +516,7 @@ class PeriodicNotesToolHandler(ToolHandler):
         if type not in valid_types:
             raise RuntimeError(f"Invalid type: {type}. Must be one of: {', '.join(valid_types)}")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
         content = api.get_periodic_note(period,type)
 
         return [
@@ -574,7 +576,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         if not isinstance(include_content, bool):
             raise RuntimeError(f"Invalid include_content: {include_content}. Must be a boolean")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
         results = api.get_recent_periodic_notes(period, limit, include_content)
 
         return [
@@ -621,7 +623,7 @@ class RecentChangesToolHandler(ToolHandler):
         if not isinstance(days, int) or days < 1:
             raise RuntimeError(f"Invalid days: {days}. Must be a positive integer")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, protocol=obsidian_protocol, host=obsidian_host, port=obsidian_port)
         results = api.get_recent_changes(limit, days)
 
         return [


### PR DESCRIPTION
## Summary

- `tools.py` reads `OBSIDIAN_HOST` from env but ignores `OBSIDIAN_PROTOCOL` and `OBSIDIAN_PORT`
- All `Obsidian()` instantiations only pass `api_key` and `host`, so `protocol` and `port` always fall back to constructor defaults (`https` / `27124`)
- This prevents users from configuring the insecure HTTP server (port 27123) or custom ports via environment variables

This PR adds reading of `OBSIDIAN_PROTOCOL` and `OBSIDIAN_PORT` env vars in `tools.py` and passes them explicitly to every `Obsidian()` constructor call, consistent with the existing `OBSIDIAN_HOST` pattern.

## Test plan

- [ ] Set `OBSIDIAN_PROTOCOL=http` and `OBSIDIAN_PORT=27123` in MCP server env config
- [ ] Enable insecure server in Obsidian Local REST API plugin settings
- [ ] Verify MCP tools connect successfully via HTTP on the configured port
- [ ] Verify default behavior (HTTPS on 27124) still works when env vars are not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)