### PR TITLE
fix: UTF-8 stdio on Windows (#135) and auto-qualify bare heading paths (#125)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pyright>=1.1.389",
+    "pytest>=8.0",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
 
 [project.scripts]
 mcp-obsidian = "mcp_obsidian:main"

--- a/src/mcp_obsidian/__init__.py
+++ b/src/mcp_obsidian/__init__.py
@@ -1,3 +1,13 @@
+import sys
+
+# Force UTF-8 on stdio before the MCP library wraps the streams. Without this,
+# Windows defaults stdin/stdout to the active code page (typically cp1252),
+# which mangles non-ASCII bytes in the JSON-RPC payloads. See issue #135.
+if hasattr(sys.stdin, "reconfigure"):
+    sys.stdin.reconfigure(encoding="utf-8")
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
 from . import server
 import asyncio
 

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -115,12 +115,12 @@ class Obsidian():
     
     def append_content(self, filepath: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
-        
+
         def call_fn():
             response = requests.post(
-                url, 
-                headers=self._get_headers() | {'Content-Type': 'text/markdown'}, 
-                data=content,
+                url,
+                headers=self._get_headers() | {'Content-Type': 'text/markdown; charset=utf-8'},
+                data=content.encode("utf-8"),
                 verify=self.verify_ssl,
                 timeout=self.timeout
             )
@@ -128,19 +128,23 @@ class Obsidian():
             return None
 
         return self._safe_call(call_fn)
-    
+
     def patch_content(self, filepath: str, operation: str, target_type: str, target: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
-        
+
+        # NOTE: The Local REST API rejects 'text/markdown; charset=utf-8' on
+        # PATCH (error 40012) — its PATCH parser only accepts the plain
+        # 'text/markdown' form. We still send the body as utf-8 bytes so the
+        # encoding is unambiguous on the wire.
         headers = self._get_headers() | {
             'Content-Type': 'text/markdown',
             'Operation': operation,
             'Target-Type': target_type,
             'Target': urllib.parse.quote(target)
         }
-        
+
         def call_fn():
-            response = requests.patch(url, headers=headers, data=content, verify=self.verify_ssl, timeout=self.timeout)
+            response = requests.patch(url, headers=headers, data=content.encode("utf-8"), verify=self.verify_ssl, timeout=self.timeout)
             response.raise_for_status()
             return None
 
@@ -148,12 +152,12 @@ class Obsidian():
 
     def put_content(self, filepath: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
-        
+
         def call_fn():
             response = requests.put(
-                url, 
-                headers=self._get_headers() | {'Content-Type': 'text/markdown'}, 
-                data=content,
+                url,
+                headers=self._get_headers() | {'Content-Type': 'text/markdown; charset=utf-8'},
+                data=content.encode("utf-8"),
                 verify=self.verify_ssl,
                 timeout=self.timeout
             )

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -1,3 +1,4 @@
+import re
 import requests
 import urllib.parse
 import os
@@ -130,6 +131,33 @@ class Obsidian():
         return self._safe_call(call_fn)
 
     def patch_content(self, filepath: str, operation: str, target_type: str, target: str, content: str) -> Any:
+        try:
+            return self._patch_content_raw(filepath, operation, target_type, target, content)
+        except Exception as e:
+            # The Local REST API requires fully qualified heading paths like
+            # "Outer::Inner". If the caller passed a bare heading name and the
+            # server replied with 40080 invalid-target, try to auto-qualify by
+            # parsing the file's heading hierarchy. See issue #125.
+            if target_type != "heading" or "::" in target or "Error 40080" not in str(e):
+                raise
+
+            try:
+                file_content = self.get_file_contents(filepath)
+            except Exception:
+                raise e
+
+            candidates = _find_heading_paths(file_content, target)
+            if len(candidates) == 1:
+                qualified = candidates[0]
+                return self._patch_content_raw(filepath, operation, target_type, qualified, content)
+            if len(candidates) > 1:
+                raise Exception(
+                    f"Ambiguous heading '{target}'. Candidates: {', '.join(candidates)}. "
+                    "Specify the qualified path with '::' delimiter."
+                )
+            raise
+
+    def _patch_content_raw(self, filepath: str, operation: str, target_type: str, target: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
 
         # NOTE: The Local REST API rejects 'text/markdown; charset=utf-8' on
@@ -293,3 +321,39 @@ class Obsidian():
             return response.json()
 
         return self._safe_call(call_fn)
+
+
+_HEADING_RE = re.compile(r"^(#+)\s+(.+?)\s*$")
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def _find_heading_paths(content: str, target: str) -> list[str]:
+    """Return fully-qualified heading paths whose last segment matches target case-insensitively.
+
+    Headings inside fenced code blocks (``` or ~~~) are ignored. The qualified
+    path joins all enclosing heading texts with '::' (matching the Local REST
+    API's heading-target syntax).
+    """
+    in_fence = False
+    stack: list[tuple[int, str]] = []
+    matches: list[str] = []
+    target_lower = target.lower()
+
+    for line in content.split("\n"):
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _HEADING_RE.match(line)
+        if not m:
+            continue
+        level = len(m.group(1))
+        text = m.group(2).strip()
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+        stack.append((level, text))
+        if text.lower() == target_lower:
+            matches.append("::".join(t for _, t in stack))
+
+    return matches

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -235,7 +235,13 @@ class PatchContentToolHandler(ToolHandler):
    def get_tool_description(self):
        return Tool(
            name=self.name,
-           description="Insert content into an existing note relative to a heading, block reference, or frontmatter field.",
+           description=(
+               "Insert content into an existing note relative to a heading, block reference, "
+               "or frontmatter field. For target_type='heading', target must be the fully "
+               "qualified heading path joined with '::' (e.g. 'Outer::Inner'). Bare heading "
+               "names (without '::') will be auto-qualified if they match exactly one heading "
+               "in the file."
+           ),
            inputSchema={
                "type": "object",
                "properties": {
@@ -255,8 +261,13 @@ class PatchContentToolHandler(ToolHandler):
                        "enum": ["heading", "block", "frontmatter"]
                    },
                    "target": {
-                       "type": "string", 
-                       "description": "Target identifier (heading path, block reference, or frontmatter field)"
+                       "type": "string",
+                       "description": (
+                           "Target identifier. For target_type='heading': fully qualified "
+                           "path with '::' delimiter, e.g. 'Section::Subsection'. Bare names "
+                           "(no '::') are auto-qualified if unambiguous. For 'block': the "
+                           "block reference id. For 'frontmatter': the YAML field name."
+                       )
                    },
                    "content": {
                        "type": "string",

--- a/tests/test_obsidian_heading_fallback.py
+++ b/tests/test_obsidian_heading_fallback.py
@@ -1,0 +1,170 @@
+"""Tests for the bare-heading auto-qualify fallback in patch_content (issue #125)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from mcp_obsidian.obsidian import Obsidian, _find_heading_paths
+
+
+def _make_obsidian():
+    return Obsidian(api_key="test-key", protocol="http", host="localhost", port=27123)
+
+
+def _http_error(status: int, error_code: int, message: str) -> requests.HTTPError:
+    resp = requests.Response()
+    resp.status_code = status
+    resp._content = (
+        b'{"errorCode": ' + str(error_code).encode() + b', "message": "' + message.encode() + b'"}'
+    )
+    err = requests.HTTPError(response=resp)
+    return err
+
+
+# --- _find_heading_paths unit tests ---------------------------------------
+
+
+def test_find_heading_paths_returns_qualified_path_for_unique_match():
+    content = "# Outer\n\n## Übersicht\n\nbody\n"
+    assert _find_heading_paths(content, "Übersicht") == ["Outer::Übersicht"]
+
+
+def test_find_heading_paths_case_insensitive():
+    content = "# Outer\n\n## Übersicht\n\nbody\n"
+    assert _find_heading_paths(content, "übersicht") == ["Outer::Übersicht"]
+
+
+def test_find_heading_paths_returns_all_candidates_when_ambiguous():
+    content = "# A\n\n## Übersicht\n\n# B\n\n## Übersicht\n"
+    assert _find_heading_paths(content, "Übersicht") == ["A::Übersicht", "B::Übersicht"]
+
+
+def test_find_heading_paths_returns_empty_when_no_match():
+    content = "# Outer\n\n## Other\n"
+    assert _find_heading_paths(content, "Missing") == []
+
+
+def test_find_heading_paths_ignores_headings_inside_code_fences():
+    content = "# Real\n\n```\n# Fake\n```\n\n## Übersicht\n"
+    # The "# Fake" inside the fence must not appear in any candidate path
+    paths = _find_heading_paths(content, "Übersicht")
+    assert paths == ["Real::Übersicht"]
+
+
+def test_find_heading_paths_handles_sibling_after_descent():
+    # Outer h1, then sibling h1 — stack must reset, not accumulate.
+    content = "# First\n\n## Sub\n\n# Second\n\n## Übersicht\n"
+    assert _find_heading_paths(content, "Übersicht") == ["Second::Übersicht"]
+
+
+# --- patch_content fallback integration tests -----------------------------
+
+
+def test_qualified_path_passes_through_without_get():
+    """A target already containing '::' must skip the fallback entirely."""
+    api = _make_obsidian()
+    with patch("mcp_obsidian.obsidian.requests.patch") as mock_patch, \
+         patch.object(api, "get_file_contents") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_patch.return_value = mock_resp
+
+        api.patch_content("f.md", "append", "heading", "A::B", "x")
+
+        assert mock_patch.call_count == 1
+        mock_get.assert_not_called()
+
+
+def test_bare_heading_unique_match_autoqualifies():
+    api = _make_obsidian()
+    file_content = "# Outer\n\n## Übersicht\n\nbody\n"
+
+    # First PATCH fails with 40080, second PATCH succeeds.
+    fail_resp = MagicMock()
+    fail_resp.raise_for_status.side_effect = _http_error(400, 40080, "invalid-target")
+    fail_resp.content = b'{"errorCode": 40080, "message": "invalid-target"}'
+    fail_resp.json.return_value = {"errorCode": 40080, "message": "invalid-target"}
+
+    ok_resp = MagicMock()
+    ok_resp.raise_for_status.return_value = None
+
+    with patch("mcp_obsidian.obsidian.requests.patch", side_effect=[fail_resp, ok_resp]) as mock_patch, \
+         patch.object(api, "get_file_contents", return_value=file_content) as mock_get:
+        api.patch_content("f.md", "append", "heading", "Übersicht", "x")
+
+        assert mock_patch.call_count == 2
+        mock_get.assert_called_once_with("f.md")
+        # Second call must carry the qualified target (URL-quoted)
+        second_headers = mock_patch.call_args_list[1].kwargs["headers"]
+        # urllib.parse.quote(...) escapes the colons too; check the underlying decoded value
+        assert "Outer" in second_headers["Target"] and "bersicht" in second_headers["Target"]
+
+
+def test_bare_heading_case_insensitive_match():
+    api = _make_obsidian()
+    file_content = "# Outer\n\n## Übersicht\n"
+
+    fail_resp = MagicMock()
+    fail_resp.raise_for_status.side_effect = _http_error(400, 40080, "invalid-target")
+    fail_resp.content = b'{"errorCode": 40080, "message": "invalid-target"}'
+    fail_resp.json.return_value = {"errorCode": 40080, "message": "invalid-target"}
+    ok_resp = MagicMock()
+    ok_resp.raise_for_status.return_value = None
+
+    with patch("mcp_obsidian.obsidian.requests.patch", side_effect=[fail_resp, ok_resp]), \
+         patch.object(api, "get_file_contents", return_value=file_content):
+        api.patch_content("f.md", "append", "heading", "übersicht", "x")
+        # If we got here without raising, the case-insensitive match succeeded.
+
+
+def test_bare_heading_ambiguous_raises_with_candidates():
+    api = _make_obsidian()
+    file_content = "# A\n\n## Übersicht\n\n# B\n\n## Übersicht\n"
+
+    fail_resp = MagicMock()
+    fail_resp.raise_for_status.side_effect = _http_error(400, 40080, "invalid-target")
+    fail_resp.content = b'{"errorCode": 40080, "message": "invalid-target"}'
+    fail_resp.json.return_value = {"errorCode": 40080, "message": "invalid-target"}
+
+    with patch("mcp_obsidian.obsidian.requests.patch", return_value=fail_resp), \
+         patch.object(api, "get_file_contents", return_value=file_content):
+        with pytest.raises(Exception) as excinfo:
+            api.patch_content("f.md", "append", "heading", "Übersicht", "x")
+        msg = str(excinfo.value)
+        assert "Ambiguous heading" in msg
+        assert "A::Übersicht" in msg
+        assert "B::Übersicht" in msg
+
+
+def test_bare_heading_not_found_reraises_original_error():
+    api = _make_obsidian()
+    file_content = "# Outer\n\n## Other\n"
+
+    fail_resp = MagicMock()
+    fail_resp.raise_for_status.side_effect = _http_error(400, 40080, "invalid-target")
+    fail_resp.content = b'{"errorCode": 40080, "message": "invalid-target"}'
+    fail_resp.json.return_value = {"errorCode": 40080, "message": "invalid-target"}
+
+    with patch("mcp_obsidian.obsidian.requests.patch", return_value=fail_resp), \
+         patch.object(api, "get_file_contents", return_value=file_content):
+        with pytest.raises(Exception) as excinfo:
+            api.patch_content("f.md", "append", "heading", "Missing", "x")
+        # Original error message format from _safe_call
+        assert "Error 40080" in str(excinfo.value)
+
+
+def test_non_heading_target_type_does_not_trigger_fallback():
+    """For target_type='block' or 'frontmatter', a 40080 error must propagate as-is."""
+    api = _make_obsidian()
+
+    fail_resp = MagicMock()
+    fail_resp.raise_for_status.side_effect = _http_error(400, 40080, "invalid-target")
+    fail_resp.content = b'{"errorCode": 40080, "message": "invalid-target"}'
+    fail_resp.json.return_value = {"errorCode": 40080, "message": "invalid-target"}
+
+    with patch("mcp_obsidian.obsidian.requests.patch", return_value=fail_resp), \
+         patch.object(api, "get_file_contents") as mock_get:
+        with pytest.raises(Exception):
+            api.patch_content("f.md", "append", "block", "blk-id", "x")
+        mock_get.assert_not_called()

--- a/tests/test_obsidian_utf8.py
+++ b/tests/test_obsidian_utf8.py
@@ -1,0 +1,50 @@
+"""Tests for UTF-8 encoding in write requests (issue #135)."""
+
+from unittest.mock import MagicMock, patch
+
+from mcp_obsidian.obsidian import Obsidian
+
+
+SAMPLE = "Hallo — Größe für Müller-Lüdenscheidt 🚀"
+
+
+def _make_obsidian():
+    return Obsidian(api_key="test-key", protocol="http", host="localhost", port=27123)
+
+
+def _ok_response():
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_append_content_sends_utf8_bytes_and_charset():
+    api = _make_obsidian()
+    with patch("mcp_obsidian.obsidian.requests.post", return_value=_ok_response()) as mock_post:
+        api.append_content("f.md", SAMPLE)
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["data"] == SAMPLE.encode("utf-8")
+        assert isinstance(kwargs["data"], (bytes, bytearray))
+        assert kwargs["headers"]["Content-Type"] == "text/markdown; charset=utf-8"
+
+
+def test_patch_content_sends_utf8_bytes_with_plain_content_type():
+    """PATCH endpoint rejects charset in Content-Type (error 40012), so we send
+    the body as utf-8 bytes but keep the header plain 'text/markdown'."""
+    api = _make_obsidian()
+    with patch("mcp_obsidian.obsidian.requests.patch", return_value=_ok_response()) as mock_patch:
+        api.patch_content("f.md", "append", "heading", "A::B", SAMPLE)
+        kwargs = mock_patch.call_args.kwargs
+        assert kwargs["data"] == SAMPLE.encode("utf-8")
+        assert isinstance(kwargs["data"], (bytes, bytearray))
+        assert kwargs["headers"]["Content-Type"] == "text/markdown"
+
+
+def test_put_content_sends_utf8_bytes_and_charset():
+    api = _make_obsidian()
+    with patch("mcp_obsidian.obsidian.requests.put", return_value=_ok_response()) as mock_put:
+        api.put_content("f.md", SAMPLE)
+        kwargs = mock_put.call_args.kwargs
+        assert kwargs["data"] == SAMPLE.encode("utf-8")
+        assert isinstance(kwargs["data"], (bytes, bytearray))
+        assert kwargs["headers"]["Content-Type"] == "text/markdown; charset=utf-8"


### PR DESCRIPTION
## Summary

Two related bugs that surface together when LLMs drive the server on Windows.

**Issue #135 — UTF-8 mojibake on Windows.** `sys.stdin`/`sys.stdout` default to the active code page (typically cp1252). The MCP stdio reader wraps these mis-configured streams before the JSON-RPC payloads arrive, corrupting any non-ASCII bytes (em-dashes, umlauts, emojis) end-to-end. Fix:
- Reconfigure stdin/stdout to UTF-8 in `__init__.py` **before** `from . import server` triggers the MCP import chain.
- Defense-in-depth: send write-request bodies as explicit UTF-8 bytes (`requests` defaults to latin-1 for str bodies without a charset header). `append_content` and `put_content` also advertise `charset=utf-8` in `Content-Type`; `patch_content` keeps plain `text/markdown` because the Local REST API's PATCH endpoint rejects charset parameters with error 40012.

**Issue #125 — `patch_content` heading targets require fully qualified `::` paths.** The Local REST API requires `target=\"Outer::Inner\"` for `target_type=heading`; bare names fail with `Error 40080: invalid-target`. Not documented in the tool description, so LLMs guess wrong. Fix:
- Clarify in the tool description that headings need a fully qualified `::` path, with example.
- Wrapper-level fallback in `Obsidian.patch_content`: when the call fails with 40080 and the target has no `::`, parse the file's heading hierarchy, match the bare name **case-insensitively** against the leaf segment, and retry with the qualified path.
  - 1 match → retry transparently.
  - >1 match → raise with all candidate paths listed.
  - 0 match → re-raise the original 40080.
  - Headings inside fenced code blocks are ignored when building the hierarchy.

## Commits

- ``fix(encoding): force utf-8 on stdio for Windows``
- ``fix(encoding): explicit utf-8 in write requests``
- ``fix(patch_content): clarify qualified heading path in description``
- ``feat(patch_content): fallback to auto-qualify bare heading targets``
- ``test: heading qualification fallback and utf-8 roundtrip``

Adds ``pytest`` as a dev dependency and introduces a ``tests/`` directory (none existed before).

## Test plan

- [x] 15 unit tests, all green: heading-path parser (qualified/bare/case-insensitive/ambiguous/not-found/code-fence handling/sibling-descent) and UTF-8 request-body shape for all three write methods. Run with ``OBSIDIAN_API_KEY=test pytest -q``.
- [x] Live smoke test against a real Obsidian vault on Windows:
  - ``patch_content(filepath, \"append\", \"heading\", \"Übersicht\", ...)`` — bare name auto-qualifies.
  - same with ``\"übersicht\"`` (lowercase) — case-insensitive match succeeds.
  - file with two ``## Übersicht`` under different H1s — Exception lists both candidates, file unchanged.
  - ``append_content`` and ``put_content`` with ``\"Hallo — Größe für Müller-Lüdenscheidt 🚀\"`` plus CJK/emoji payloads — full roundtrip via ``get_file_contents`` returns identical input.

Closes #125
Closes #135