### PR TITLE
docs+test(put_content): clarify overwrite semantics and add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pyright>=1.1.389",
+    "pytest>=8.0",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
 
 [project.scripts]
 mcp-obsidian = "mcp_obsidian:main"

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -294,7 +294,13 @@ class PutContentToolHandler(ToolHandler):
    def get_tool_description(self):
        return Tool(
            name=self.name,
-           description="Create a new file in your vault or update the content of an existing one in your vault.",
+           description=(
+               "Creates a new file, or COMPLETELY OVERWRITES the content of an existing "
+               "file. The previous content is lost. "
+               "Use `obsidian_append_content` to add content to a file without erasing "
+               "what's already there. Use `obsidian_patch_content` to modify a specific "
+               "heading, block or frontmatter field while keeping the rest intact."
+           ),
            inputSchema={
                "type": "object",
                "properties": {
@@ -305,7 +311,7 @@ class PutContentToolHandler(ToolHandler):
                    },
                    "content": {
                        "type": "string",
-                       "description": "Content of the file you would like to upload"
+                       "description": "Full file content. Replaces existing content entirely if the file already exists."
                    }
                },
                "required": ["filepath", "content"]

--- a/tests/test_obsidian_put_content.py
+++ b/tests/test_obsidian_put_content.py
@@ -1,0 +1,74 @@
+"""Tests for put_content overwrite semantics and roundtrip behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from mcp_obsidian.obsidian import Obsidian
+
+
+def _make_obsidian():
+    return Obsidian(api_key="test-key", protocol="http", host="localhost", port=27123)
+
+
+def _ok_response():
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_put_content_uses_http_put_at_vault_path():
+    """put_content must hit PUT /vault/{filepath} — not POST (append) or PATCH."""
+    api = _make_obsidian()
+    with patch("mcp_obsidian.obsidian.requests.put", return_value=_ok_response()) as mock_put, \
+         patch("mcp_obsidian.obsidian.requests.post") as mock_post, \
+         patch("mcp_obsidian.obsidian.requests.patch") as mock_patch:
+        api.put_content("notes/test.md", "hello")
+        assert mock_put.call_count == 1
+        mock_post.assert_not_called()
+        mock_patch.assert_not_called()
+        url = mock_put.call_args.args[0]
+        assert url.endswith("/vault/notes/test.md")
+
+
+def test_put_content_sends_full_body_verbatim():
+    """The entire content arg must arrive as the request body — this is the
+    contract that makes put_content suitable for full-file overwrites."""
+    api = _make_obsidian()
+    payload = "# Title\n\nLine one\nLine two\n"
+    with patch("mcp_obsidian.obsidian.requests.put", return_value=_ok_response()) as mock_put:
+        api.put_content("file.md", payload)
+        sent = mock_put.call_args.kwargs["data"]
+        assert sent == payload.encode("utf-8") or sent == payload
+
+
+def test_put_content_overwrites_on_second_call():
+    """Two consecutive put_content calls each send their own full body —
+    the second is not appended to the first. This is the overwrite contract."""
+    api = _make_obsidian()
+    with patch("mcp_obsidian.obsidian.requests.put", return_value=_ok_response()) as mock_put:
+        api.put_content("file.md", "first version")
+        api.put_content("file.md", "second version")
+        assert mock_put.call_count == 2
+        first_body = mock_put.call_args_list[0].kwargs["data"]
+        second_body = mock_put.call_args_list[1].kwargs["data"]
+        assert b"first version" in (first_body if isinstance(first_body, bytes) else first_body.encode())
+        assert b"second version" in (second_body if isinstance(second_body, bytes) else second_body.encode())
+        # The second call must NOT carry the first version's payload
+        assert b"first version" not in (second_body if isinstance(second_body, bytes) else second_body.encode())
+
+
+def test_put_content_roundtrip_via_mocked_get():
+    """End-to-end shape: put_content(c) → get_file_contents() returns c.
+    Uses two independent mocks since the real API stores state between calls;
+    here we just verify our wrapper round-trips the body correctly."""
+    api = _make_obsidian()
+    payload = "# Roundtrip\n\nbody\n"
+
+    get_resp = MagicMock()
+    get_resp.raise_for_status.return_value = None
+    get_resp.text = payload
+
+    with patch("mcp_obsidian.obsidian.requests.put", return_value=_ok_response()), \
+         patch("mcp_obsidian.obsidian.requests.get", return_value=get_resp):
+        api.put_content("rt.md", payload)
+        result = api.get_file_contents("rt.md")
+        assert result == payload


### PR DESCRIPTION
## Summary

Small follow-up to #44 (which added ``put_content``). The current tool description (\"Create a new file in your vault or update the content of an existing one\") doesn't make clear that calling ``obsidian_put_content`` on an existing file **fully replaces** its content. LLM callers can confuse it with ``append_content`` / ``patch_content`` and accidentally erase work.

This PR:
- Rewrites the tool description to spell out the overwrite semantics and cross-references ``append_content`` and ``patch_content`` for non-destructive alternatives.
- Adds 4 unit tests for ``put_content`` (HTTP method + URL shape, body passed through verbatim, two-call overwrite semantics, put-then-get roundtrip).
- Introduces ``pytest`` as a dev dependency and a ``tests/`` directory.

Independent of #139 — branched from ``main``, no overlapping code with the heading/UTF-8 fixes.

## Commits

- ``docs(put_content): clarify overwrite semantics in tool description``
- ``test: pytest setup and put_content overwrite/roundtrip tests``

## Test plan

- [x] ``pytest -q`` — 4/4 green.
- [x] Live smoke test against a real Obsidian vault:
  - ``put_content(file, \"v1\")`` then ``get_file_contents(file)`` → ``\"v1\"``.
  - ``put_content(file, \"v2 fully replaced\")`` then ``get_file_contents(file)`` → no trace of v1.