### PR TITLE
Update tools.py - feat: support OBSIDIAN_PORT and OBSIDIAN_PROTOCOL e…

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -11,6 +11,8 @@ from . import obsidian
 
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+obsidian_port = int(os.getenv("OBSIDIAN_PORT", "27124"))
+obsidian_protocol = os.getenv("OBSIDIAN_PROTOCOL", "https")
 
 if api_key == "":
     raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
@@ -44,7 +46,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
 
         files = api.list_files_in_vault()
 
@@ -80,7 +82,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         if "dirpath" not in args:
             raise RuntimeError("dirpath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
 
         files = api.list_files_in_dir(args["dirpath"])
 
@@ -116,7 +118,7 @@ class GetFileContentsToolHandler(ToolHandler):
         if "filepath" not in args:
             raise RuntimeError("filepath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
 
         content = api.get_file_contents(args["filepath"])
 
@@ -159,7 +161,7 @@ class SearchToolHandler(ToolHandler):
 
         context_length = args.get("context_length", 100)
         
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
         results = api.search(args["query"], context_length)
         
         formatted_results = []
@@ -218,7 +220,7 @@ class AppendContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
        api.append_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -282,7 +284,7 @@ class PatchContentToolHandler(ToolHandler):
        if not all(k in args for k in ["filepath", "operation", "target_type", "target", "content"]):
            raise RuntimeError("filepath, operation, target_type, target and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
        api.patch_content(
            args.get("filepath", ""),
            args.get("operation", ""),
@@ -333,7 +335,7 @@ class PutContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
        api.put_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -377,7 +379,7 @@ class DeleteFileToolHandler(ToolHandler):
        if not args.get("confirm", False):
            raise RuntimeError("confirm must be set to true to delete a file")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
        api.delete_file(args["filepath"])
 
        return [
@@ -441,7 +443,7 @@ class ComplexSearchToolHandler(ToolHandler):
        if "query" not in args:
            raise RuntimeError("query argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
        results = api.search_json(args.get("query", ""))
 
        return [
@@ -486,7 +488,7 @@ class SearchByTagToolHandler(ToolHandler):
        if "tag" not in args:
            raise RuntimeError("tag argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
        paths = api.search_by_tag(args["tag"], args.get("dirpath"))
 
        return [
@@ -527,7 +529,7 @@ class GetFrontmatterToolHandler(ToolHandler):
        if "filepath" not in args:
            raise RuntimeError("filepath argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
        fm = api.get_frontmatter(args["filepath"])
 
        return [
@@ -567,7 +569,7 @@ class BatchGetFileContentsToolHandler(ToolHandler):
         if "filepaths" not in args:
             raise RuntimeError("filepaths argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
         content = api.get_batch_file_contents(args["filepaths"])
 
         return [
@@ -618,8 +620,8 @@ class PeriodicNotesToolHandler(ToolHandler):
         if type not in valid_types:
             raise RuntimeError(f"Invalid type: {type}. Must be one of: {', '.join(valid_types)}")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-        content = api.get_periodic_note(period,type)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
+        content = api.get_periodic_note(period, type)
 
         return [
             TextContent(
@@ -678,7 +680,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         if not isinstance(include_content, bool):
             raise RuntimeError(f"Invalid include_content: {include_content}. Must be a boolean")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
         results = api.get_recent_periodic_notes(period, limit, include_content)
 
         return [
@@ -725,7 +727,7 @@ class RecentChangesToolHandler(ToolHandler):
         if not isinstance(days, int) or days < 1:
             raise RuntimeError(f"Invalid days: {days}. Must be a positive integer")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host, port=obsidian_port, protocol=obsidian_protocol)
         results = api.get_recent_changes(limit, days)
 
         return [


### PR DESCRIPTION
…nvironment variables

OBSIDIAN_HOST is already read from the environment, but port and protocol  are still hardcoded to class defaults (27124 and https). This means remote  Obsidian instances on non-default ports or HTTP-only setups silently fail  regardless of configuration.

Adds OBSIDIAN_PORT and OBSIDIAN_PROTOCOL env var support to match the  existing OBSIDIAN_HOST pattern.

Discovered while connecting to a remote vault over Tailscale.