### PR TITLE
fix: add __main__.py and support OBSIDIAN_PROTOCOL/HOST/PORT env vars for HTTPS

### DIFF
--- a/src/mcp_obsidian/__main__.py
+++ b/src/mcp_obsidian/__main__.py
@@ -1,0 +1,22 @@
+import asyncio
+import os
+import sys
+
+# Load environment variables from .env file if present
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+# Debug output to stderr for troubleshooting
+print(f"[mcp-obsidian] OBSIDIAN_API_KEY set: {bool(os.getenv('OBSIDIAN_API_KEY'))}", file=sys.stderr)
+print(f"[mcp-obsidian] OBSIDIAN_PROTOCOL={os.getenv('OBSIDIAN_PROTOCOL')}", file=sys.stderr)
+print(f"[mcp-obsidian] OBSIDIAN_HOST={os.getenv('OBSIDIAN_HOST')}", file=sys.stderr)
+print(f"[mcp-obsidian] OBSIDIAN_PORT={os.getenv('OBSIDIAN_PORT')}", file=sys.stderr)
+sys.stderr.flush()
+
+from mcp_obsidian.server import main
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -11,9 +11,21 @@ from . import obsidian
 
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+obsidian_port = int(os.getenv("OBSIDIAN_PORT", "27124"))
+obsidian_protocol = os.getenv("OBSIDIAN_PROTOCOL", "https")
 
 if api_key == "":
     raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+
+def _make_client():
+    """Create an Obsidian client with environment-based configuration."""
+    return obsidian.Obsidian(
+        api_key=api_key,
+        host=obsidian_host,
+        port=obsidian_port,
+        protocol=obsidian_protocol,
+    )
+
 
 TOOL_LIST_FILES_IN_VAULT = "obsidian_list_files_in_vault"
 TOOL_LIST_FILES_IN_DIR = "obsidian_list_files_in_dir"
@@ -44,7 +56,7 @@ class ListFilesInVaultToolHandler(ToolHandler):
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
 
         files = api.list_files_in_vault()
 
@@ -80,7 +92,7 @@ class ListFilesInDirToolHandler(ToolHandler):
         if "dirpath" not in args:
             raise RuntimeError("dirpath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
 
         files = api.list_files_in_dir(args["dirpath"])
 
@@ -116,7 +128,7 @@ class GetFileContentsToolHandler(ToolHandler):
         if "filepath" not in args:
             raise RuntimeError("filepath argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
 
         content = api.get_file_contents(args["filepath"])
 
@@ -159,7 +171,7 @@ class SearchToolHandler(ToolHandler):
 
         context_length = args.get("context_length", 100)
         
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         results = api.search(args["query"], context_length)
         
         formatted_results = []
@@ -218,7 +230,7 @@ class AppendContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.append_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -282,7 +294,7 @@ class PatchContentToolHandler(ToolHandler):
        if not all(k in args for k in ["filepath", "operation", "target_type", "target", "content"]):
            raise RuntimeError("filepath, operation, target_type, target and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.patch_content(
            args.get("filepath", ""),
            args.get("operation", ""),
@@ -333,7 +345,7 @@ class PutContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.put_content(args.get("filepath", ""), args["content"])
 
        return [
@@ -377,7 +389,7 @@ class DeleteFileToolHandler(ToolHandler):
        if not args.get("confirm", False):
            raise RuntimeError("confirm must be set to true to delete a file")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        api.delete_file(args["filepath"])
 
        return [
@@ -441,7 +453,7 @@ class ComplexSearchToolHandler(ToolHandler):
        if "query" not in args:
            raise RuntimeError("query argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        results = api.search_json(args.get("query", ""))
 
        return [
@@ -486,7 +498,7 @@ class SearchByTagToolHandler(ToolHandler):
        if "tag" not in args:
            raise RuntimeError("tag argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        paths = api.search_by_tag(args["tag"], args.get("dirpath"))
 
        return [
@@ -527,7 +539,7 @@ class GetFrontmatterToolHandler(ToolHandler):
        if "filepath" not in args:
            raise RuntimeError("filepath argument missing in arguments")
 
-       api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+       api = _make_client()
        fm = api.get_frontmatter(args["filepath"])
 
        return [
@@ -567,7 +579,7 @@ class BatchGetFileContentsToolHandler(ToolHandler):
         if "filepaths" not in args:
             raise RuntimeError("filepaths argument missing in arguments")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         content = api.get_batch_file_contents(args["filepaths"])
 
         return [
@@ -618,7 +630,7 @@ class PeriodicNotesToolHandler(ToolHandler):
         if type not in valid_types:
             raise RuntimeError(f"Invalid type: {type}. Must be one of: {', '.join(valid_types)}")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         content = api.get_periodic_note(period,type)
 
         return [
@@ -678,7 +690,7 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
         if not isinstance(include_content, bool):
             raise RuntimeError(f"Invalid include_content: {include_content}. Must be a boolean")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         results = api.get_recent_periodic_notes(period, limit, include_content)
 
         return [
@@ -725,7 +737,7 @@ class RecentChangesToolHandler(ToolHandler):
         if not isinstance(days, int) or days < 1:
             raise RuntimeError(f"Invalid days: {days}. Must be a positive integer")
 
-        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api = _make_client()
         results = api.get_recent_changes(limit, days)
 
         return [


### PR DESCRIPTION
## Problem

1. `python -m mcp_obsidian` fails because `__main__.py` is missing from the package.
2. When running Obsidian via HTTPS (e.g. behind a reverse proxy), there is no way to configure `protocol`, `host`, or `port` except editing source code. The `OBSIDIAN_API_KEY` env var is supported, but `OBSIDIAN_PROTOCOL`, `OBSIDIAN_HOST`, `OBSIDIAN_PORT` are not.

## Changes

### 1. Add `src/mcp_obsidian/__main__.py`
Allows `python -m mcp_obsidian` to work correctly (required for MCP server configs that use `python -m` instead of the bundled `.exe`).

### 2. Support all Obsidian connection env vars in `src/mcp_obsidian/tools.py`
- Read `OBSIDIAN_HOST`, `OBSIDIAN_PORT`, `OBSIDIAN_PROTOCOL` from environment
- Introduce `_make_client()` factory to centralize `Obsidian()` client creation
- All 13 tool functions now use `_make_client()` instead of hardcoded `obsidian_host`

### 3. Also fixed in `obsidian.py` (included in this branch)
- `__init__` parameters `protocol`/`host`/`port` default to `None`, then fall back to `os.getenv()` with sensible defaults
- This allows env vars to override defaults when using the Python package directly

## Testing

- Tested with two Obsidian vaults on different ports (27124, 27126) both via HTTPS
- MCP server config using `python -m mcp_obsidian` with env vars works correctly
- All 13 MCP tools (list_files, get_file, etc.) confirmed working

## Related
- See also PR #119 (similar intent but does not include `__main__.py` or `tools.py` changes)

---

**Note**: If using the PyInstaller-bundled `.exe`, environment variables have no effect because the `.py` files are frozen into the binary. Use `python -m mcp_obsidian` instead for env var support.