### PR TITLE
security: fix path traversal, SSL default, error leakage, and input hardening

### DIFF
--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -1,24 +1,45 @@
+import posixpath
 import re
 import requests
 import urllib.parse
 import os
 from typing import Any
 
+
+def _validate_vault_path(path: str) -> str:
+    """Reject paths that would escape the vault root via traversal sequences.
+
+    Checks both the raw value and the URL-decoded form so that encoded
+    variants like ``%2e%2e%2f`` are also caught.
+
+    Returns the validated path stripped of a leading slash (the REST API
+    treats paths as vault-relative so a leading slash is redundant and
+    confusing).
+
+    Raises ValueError for any path that resolves outside the vault root.
+    """
+    for candidate in (path, urllib.parse.unquote(path)):
+        normalised = posixpath.normpath(candidate.replace("\\", "/"))
+        if normalised == ".." or normalised.startswith("../") or "/../" in normalised:
+            raise ValueError(f"Invalid vault path (traversal detected): {path!r}")
+    return path.lstrip("/")
+
+
 class Obsidian():
     def __init__(
-            self, 
+            self,
             api_key: str,
             protocol: str = os.getenv('OBSIDIAN_PROTOCOL', 'https').lower(),
             host: str = str(os.getenv('OBSIDIAN_HOST', '127.0.0.1')),
             port: int = int(os.getenv('OBSIDIAN_PORT', '27124')),
-            verify_ssl: bool = False,
+            verify_ssl: bool = os.getenv('OBSIDIAN_VERIFY_SSL', 'true').lower() != 'false',
         ):
         self.api_key = api_key
-        
+
         if protocol == 'http':
             self.protocol = 'http'
         else:
-            self.protocol = 'https' # Default to https for any other value, including 'https'
+            self.protocol = 'https'  # Default to https for any other value, including 'https'
 
         self.host = host
         self.port = port
@@ -65,6 +86,7 @@ class Obsidian():
 
         
     def list_files_in_dir(self, dirpath: str) -> Any:
+        dirpath = _validate_vault_path(dirpath)
         url = f"{self.get_base_url()}/vault/{dirpath}/"
         
         def call_fn():
@@ -76,6 +98,7 @@ class Obsidian():
         return self._safe_call(call_fn)
 
     def get_file_contents(self, filepath: str) -> Any:
+        filepath = _validate_vault_path(filepath)
         url = f"{self.get_base_url()}/vault/{filepath}"
     
         def call_fn():
@@ -122,6 +145,7 @@ class Obsidian():
         return self._safe_call(call_fn)
     
     def append_content(self, filepath: str, content: str) -> Any:
+        filepath = _validate_vault_path(filepath)
         url = f"{self.get_base_url()}/vault/{filepath}"
 
         def call_fn():
@@ -165,6 +189,7 @@ class Obsidian():
             raise
 
     def _patch_content_raw(self, filepath: str, operation: str, target_type: str, target: str, content: str) -> Any:
+        filepath = _validate_vault_path(filepath)
         url = f"{self.get_base_url()}/vault/{filepath}"
 
         # NOTE: The Local REST API rejects 'text/markdown; charset=utf-8' on
@@ -186,6 +211,7 @@ class Obsidian():
         return self._safe_call(call_fn)
 
     def put_content(self, filepath: str, content: str) -> Any:
+        filepath = _validate_vault_path(filepath)
         url = f"{self.get_base_url()}/vault/{filepath}"
 
         def call_fn():
@@ -203,13 +229,14 @@ class Obsidian():
     
     def delete_file(self, filepath: str) -> Any:
         """Delete a file or directory from the vault.
-        
+
         Args:
             filepath: Path to the file to delete (relative to vault root)
-            
+
         Returns:
             None on success
         """
+        filepath = _validate_vault_path(filepath)
         url = f"{self.get_base_url()}/vault/{filepath}"
         
         def call_fn():
@@ -273,6 +300,7 @@ class Obsidian():
         notes without frontmatter; never raises for missing frontmatter
         (only for missing files or transport errors).
         """
+        filepath = _validate_vault_path(filepath)
         url = f"{self.get_base_url()}/vault/{filepath}"
         headers = self._get_headers() | {
             'Accept': 'application/vnd.olrapi.note+json'
@@ -352,12 +380,15 @@ class Obsidian():
         Returns:
             List of recently modified files with metadata
         """
-        # Build the DQL query
+        # Build the DQL query — explicit int() cast prevents injection if
+        # upstream validation is ever relaxed or bypassed.
+        safe_days = int(days)
+        safe_limit = int(limit)
         query_lines = [
             "TABLE file.mtime",
-            f"WHERE file.mtime >= date(today) - dur({days} days)",
+            f"WHERE file.mtime >= date(today) - dur({safe_days} days)",
             "SORT file.mtime DESC",
-            f"LIMIT {limit}"
+            f"LIMIT {safe_limit}"
         ]
         
         # Join with proper DQL line breaks

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -10,7 +10,9 @@ def _validate_vault_path(path: str) -> str:
     """Reject paths that would escape the vault root via traversal sequences.
 
     Checks both the raw value and the URL-decoded form so that encoded
-    variants like ``%2e%2e%2f`` are also caught.
+    variants like ``%2e%2e%2f`` are also caught.  The leading slash is
+    stripped *before* normalisation so that absolute-looking inputs such as
+    ``/../../etc/passwd`` are treated as relative paths and correctly caught.
 
     Returns the validated path stripped of a leading slash (the REST API
     treats paths as vault-relative so a leading slash is redundant and
@@ -18,11 +20,12 @@ def _validate_vault_path(path: str) -> str:
 
     Raises ValueError for any path that resolves outside the vault root.
     """
-    for candidate in (path, urllib.parse.unquote(path)):
+    stripped = path.lstrip("/")
+    for candidate in (stripped, urllib.parse.unquote(stripped)):
         normalised = posixpath.normpath(candidate.replace("\\", "/"))
-        if normalised == ".." or normalised.startswith("../") or "/../" in normalised:
+        if normalised in ("..", ".") or normalised.startswith("../") or "/../" in normalised:
             raise ValueError(f"Invalid vault path (traversal detected): {path!r}")
-    return path.lstrip("/")
+    return stripped
 
 
 class Obsidian():

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from collections.abc import Sequence
-from functools import lru_cache
 from typing import Any
 import os
 from dotenv import load_dotenv
@@ -23,9 +22,9 @@ from . import tools
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mcp-obsidian")
 
-api_key = os.getenv("OBSIDIAN_API_KEY")
+api_key = os.getenv("OBSIDIAN_API_KEY", "").strip()
 if not api_key:
-    raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+    raise ValueError("OBSIDIAN_API_KEY environment variable required.")
 
 app = Server("mcp-obsidian")
 
@@ -78,8 +77,8 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent | ImageCo
     try:
         return tool_handler.run_tool(arguments)
     except Exception as e:
-        logger.error(str(e))
-        raise RuntimeError(f"Caught Exception. Error: {str(e)}")
+        logger.error("Tool %s failed: %s", name, e, exc_info=True)
+        raise RuntimeError("Tool execution failed. Check server logs for details.")
 
 
 async def main():

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -9,11 +9,11 @@ import json
 import os
 from . import obsidian
 
-api_key = os.getenv("OBSIDIAN_API_KEY", "")
+api_key = os.getenv("OBSIDIAN_API_KEY", "").strip()
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
 
-if api_key == "":
-    raise ValueError(f"OBSIDIAN_API_KEY environment variable required. Working directory: {os.getcwd()}")
+if not api_key:
+    raise ValueError("OBSIDIAN_API_KEY environment variable required.")
 
 TOOL_LIST_FILES_IN_VAULT = "obsidian_list_files_in_vault"
 TOOL_LIST_FILES_IN_DIR = "obsidian_list_files_in_dir"
@@ -146,7 +146,9 @@ class SearchToolHandler(ToolHandler):
                     "context_length": {
                         "type": "integer",
                         "description": "How much context to return around the matching string (default: 100)",
-                        "default": 100
+                        "default": 100,
+                        "minimum": 1,
+                        "maximum": 10000
                     }
                 },
                 "required": ["query"]
@@ -207,7 +209,8 @@ class AppendContentToolHandler(ToolHandler):
                    },
                    "content": {
                        "type": "string",
-                       "description": "Content to append to the file"
+                       "description": "Content to append to the file",
+                       "maxLength": 5000000
                    }
                },
                "required": ["filepath", "content"]
@@ -218,8 +221,12 @@ class AppendContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
+       content = args["content"]
+       if len(content) > 5_000_000:
+           raise RuntimeError("content exceeds maximum allowed size (5 MB)")
+
        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-       api.append_content(args.get("filepath", ""), args["content"])
+       api.append_content(args.get("filepath", ""), content)
 
        return [
            TextContent(
@@ -271,7 +278,8 @@ class PatchContentToolHandler(ToolHandler):
                    },
                    "content": {
                        "type": "string",
-                       "description": "Content to insert"
+                       "description": "Content to insert",
+                       "maxLength": 5000000
                    }
                },
                "required": ["filepath", "operation", "target_type", "target", "content"]
@@ -282,13 +290,17 @@ class PatchContentToolHandler(ToolHandler):
        if not all(k in args for k in ["filepath", "operation", "target_type", "target", "content"]):
            raise RuntimeError("filepath, operation, target_type, target and content arguments required")
 
+       content = args.get("content", "")
+       if len(content) > 5_000_000:
+           raise RuntimeError("content exceeds maximum allowed size (5 MB)")
+
        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
        api.patch_content(
            args.get("filepath", ""),
            args.get("operation", ""),
            args.get("target_type", ""),
            args.get("target", ""),
-           args.get("content", "")
+           content
        )
 
        return [
@@ -322,7 +334,8 @@ class PutContentToolHandler(ToolHandler):
                    },
                    "content": {
                        "type": "string",
-                       "description": "Full file content. Replaces existing content entirely if the file already exists."
+                       "description": "Full file content. Replaces existing content entirely if the file already exists.",
+                       "maxLength": 5000000
                    }
                },
                "required": ["filepath", "content"]
@@ -333,8 +346,12 @@ class PutContentToolHandler(ToolHandler):
        if "filepath" not in args or "content" not in args:
            raise RuntimeError("filepath and content arguments required")
 
+       content = args["content"]
+       if len(content) > 5_000_000:
+           raise RuntimeError("content exceeds maximum allowed size (5 MB)")
+
        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-       api.put_content(args.get("filepath", ""), args["content"])
+       api.put_content(args.get("filepath", ""), content)
 
        return [
            TextContent(


### PR DESCRIPTION
## Summary

Security hardening PR — no new features, no breaking changes for correctly-behaved callers.

### What this fixes

| Finding | Severity | Fix |
|---|---|---|
| Path traversal — no filepath sanitization | **CRITICAL** | `_validate_vault_path()` rejects `..` sequences (raw and URL-encoded) before any URL is built |
| SSL verification disabled by default | **HIGH** | `verify_ssl` now defaults to `True`; opt-out via `OBSIDIAN_VERIFY_SSL=false` env var |
| DQL injection in `get_recent_changes` | **HIGH** | Explicit `int()` cast on `limit`/`days` before DQL interpolation |
| Error messages leak internal details | **MEDIUM** | Full exception logged server-side; generic message returned to MCP caller |
| Working directory in startup error | **MEDIUM** | Removed `os.getcwd()` from the `OBSIDIAN_API_KEY` not-set message |
| Unbounded content write size | **MEDIUM** | `maxLength: 5_000_000` in schema + runtime guard on `append`, `patch`, `put` |
| Unbounded `context_length` on search | **LOW** | Added `minimum: 1, maximum: 10000` to schema |
| API key init inconsistency | **LOW** | Consolidated to `.strip()` + falsy check in both `server.py` and `tools.py` |
| Unused `lru_cache` import | **LOW** | Removed from `server.py` |

### None of the 28 open PRs covered these issues

Checked all open PRs before opening this one. PR #97 adds SSL certificate pinning (complementary, not conflicting) and PR #79 adds a config layer — neither flips the SSL default or adds path validation.

### Breaking changes

- **SSL:** users connecting to the Obsidian REST API over HTTPS with a self-signed certificate (the default setup) will now see SSL errors unless they either set `OBSIDIAN_VERIFY_SSL=false` or supply the certificate via `OBSIDIAN_SSL_CERT_PATH` / `OBSIDIAN_SSL_CERT_BASE64` (as proposed in PR #97). The README should note this; suggested addition:
  ```
  OBSIDIAN_VERIFY_SSL=false   # set to false to skip certificate verification (default was false in <0.2.3)
  ```
- **Error messages:** callers that parse the text of `RuntimeError` messages from tool failures will receive a generic string instead of the original exception text. No legitimate use case depends on this.

## Test plan

- [ ] Confirm `_validate_vault_path("../../etc/passwd")` raises `ValueError`
- [ ] Confirm `_validate_vault_path("%2e%2e%2fetc%2fpasswd")` raises `ValueError`
- [ ] Confirm normal vault paths (`notes/foo.md`, `daily/2026-06-05.md`) pass through unchanged
- [ ] Confirm server starts with `OBSIDIAN_API_KEY` set and `OBSIDIAN_VERIFY_SSL=false` (self-signed cert flow)
- [ ] Confirm startup raises `ValueError` (no path) when `OBSIDIAN_API_KEY` is unset