### PR TITLE
feat: strip Obsidian %% comment %% blocks before sending to model

### DIFF
--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -7,7 +7,22 @@ from mcp.types import (
 )
 import json
 import os
+import re
 from . import obsidian
+
+
+def strip_obsidian_comments(text: str) -> str:
+    """Strip Obsidian %% comment %% blocks before sending content to the model.
+
+    Obsidian defines %% ... %% as hidden comments — they are excluded from
+    Reading View, PDF exports, and Obsidian Publish. This function applies the
+    same rule to MCP context, so content the user marked as a comment is not
+    forwarded to the AI without their knowledge.
+
+    Reference: https://help.obsidian.md/Editing+and+formatting/Basic+formatting+syntax#Comments
+    """
+    return re.sub(r"%%.*?%%", "", text, flags=re.DOTALL)
+
 
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
@@ -123,10 +138,10 @@ class GetFileContentsToolHandler(ToolHandler):
         return [
             TextContent(
                 type="text",
-                text=json.dumps(content, indent=2)
+                text=json.dumps(strip_obsidian_comments(content), indent=2)
             )
         ]
-    
+
 class SearchToolHandler(ToolHandler):
     def __init__(self):
         super().__init__("obsidian_simple_search")
@@ -568,7 +583,7 @@ class BatchGetFileContentsToolHandler(ToolHandler):
             raise RuntimeError("filepaths argument missing in arguments")
 
         api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
-        content = api.get_batch_file_contents(args["filepaths"])
+        content = strip_obsidian_comments(api.get_batch_file_contents(args["filepaths"]))
 
         return [
             TextContent(


### PR DESCRIPTION
## Summary

Obsidian defines `%% ... %%` as **hidden comments** — documented in [Basic formatting syntax](https://help.obsidian.md/Editing+and+formatting/Basic+formatting+syntax#Comments). They are stripped by Reading View, PDF export, and Obsidian Publish.

`mcp-obsidian` was the only Obsidian export path that forwarded `%%...%%` content to the model unchanged, silently sending content the user intended to keep hidden.

## Change

Adds `strip_obsidian_comments(text)` (~10 lines, stdlib `re` only) and applies it in `GetFileContentsToolHandler` and `BatchGetFileContentsToolHandler` before content reaches the model.

## Why this belongs in the library (not user config)

This is spec compliance, not a preference. When a user writes:

```
My public note content.

%% reminder to self: drafted while stressed, don't share %%
```

they have a reasonable expectation that the comment behaves the same way in mcp-obsidian as it does in every other Obsidian export path — i.e., it stays private.

Respecting `%%` comments is the same class of decision as respecting `---` frontmatter — it is part of the format, not a user option.

## No breaking changes

Users who want comments included in AI context can simply not use `%%` for that content.