### PR TITLE
feat: add obsidian_rename_file tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run tests
+        env:
+          OBSIDIAN_API_KEY: test-key
+        run: uv run pytest --cov=mcp_obsidian --cov-report=term-missing

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -342,6 +342,49 @@ class Obsidian():
 
         return self._safe_call(call_fn)
     
+    def rename_file(self, filepath: str, new_filepath: str) -> None:
+        """Rename (move) a markdown file by copying its content then deleting the original.
+
+        Raises if source and destination are the same path, or if the destination
+        already exists. On partial failure (write succeeded, delete failed) the
+        newly written file is cleaned up before re-raising so the vault stays
+        consistent.
+
+        Args:
+            filepath: Current path of the file (relative to vault root)
+            new_filepath: New path for the file (relative to vault root)
+        """
+        if filepath == new_filepath:
+            raise Exception("Source and destination paths are identical")
+
+        existing = self._file_exists(new_filepath)
+        if existing:
+            raise Exception(f"Destination already exists: {new_filepath}")
+
+        content = self.get_file_contents(filepath)
+        self.put_content(new_filepath, content)
+        try:
+            self.delete_file(filepath)
+        except Exception as delete_err:
+            try:
+                self.delete_file(new_filepath)
+            except Exception:
+                pass
+            raise Exception(
+                f"Rename failed: could not delete source '{filepath}' after writing "
+                f"destination '{new_filepath}'. Compensating delete attempted. "
+                f"Original error: {delete_err}"
+            )
+
+    def _file_exists(self, filepath: str) -> bool:
+        """Return True if the file exists in the vault, False if not found."""
+        url = f"{self.get_base_url()}/vault/{filepath}"
+        try:
+            response = requests.get(url, headers=self._get_headers(), verify=self.verify_ssl, timeout=self.timeout)
+            return response.status_code == 200
+        except requests.exceptions.RequestException:
+            return False
+
     def get_recent_changes(self, limit: int = 10, days: int = 90) -> Any:
         """Get recently modified files in the vault.
         

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -56,6 +56,7 @@ add_tool_handler(tools.BatchGetFileContentsToolHandler())
 add_tool_handler(tools.PeriodicNotesToolHandler())
 add_tool_handler(tools.RecentPeriodicNotesToolHandler())
 add_tool_handler(tools.RecentChangesToolHandler())
+add_tool_handler(tools.RenameFileToolHandler())
 
 @app.list_tools()
 async def list_tools() -> list[Tool]:

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -688,6 +688,66 @@ class RecentPeriodicNotesToolHandler(ToolHandler):
             )
         ]
         
+def _validate_vault_path(path: str) -> str:
+    """Reject paths that escape the vault root via traversal segments."""
+    normalized = path.lstrip("/")
+    for segment in normalized.replace("\\", "/").split("/"):
+        if segment == "..":
+            raise RuntimeError(f"Invalid path '{path}': '..' segments are not allowed")
+    return normalized
+
+
+class RenameFileToolHandler(ToolHandler):
+    def __init__(self):
+        super().__init__("obsidian_rename_file")
+
+    def get_tool_description(self):
+        return Tool(
+            name=self.name,
+            description=(
+                "Rename or move a markdown file in the vault. The file content is "
+                "preserved; only its path changes. Only .md files are supported. "
+                "Raises an error if the destination already exists."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "filepath": {
+                        "type": "string",
+                        "description": "Current path of the file (relative to vault root)",
+                        "format": "path"
+                    },
+                    "new_filepath": {
+                        "type": "string",
+                        "description": "New path for the file (relative to vault root)",
+                        "format": "path"
+                    }
+                },
+                "required": ["filepath", "new_filepath"]
+            }
+        )
+
+    def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
+        if "filepath" not in args or "new_filepath" not in args:
+            raise RuntimeError("filepath and new_filepath arguments required")
+
+        filepath = _validate_vault_path(args["filepath"])
+        new_filepath = _validate_vault_path(args["new_filepath"])
+
+        if not filepath.endswith(".md") or not new_filepath.endswith(".md"):
+            raise RuntimeError("Only .md files are supported by obsidian_rename_file")
+
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+        api.rename_file(filepath, new_filepath)
+
+        return [
+            TextContent(
+                type="text",
+                text=f"Successfully renamed {filepath} to {new_filepath}"
+            )
+        ]
+
+
 class RecentChangesToolHandler(ToolHandler):
     def __init__(self):
         super().__init__("obsidian_get_recent_changes")

--- a/tests/test_obsidian_rename.py
+++ b/tests/test_obsidian_rename.py
@@ -1,0 +1,112 @@
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import requests
+
+from mcp_obsidian.obsidian import Obsidian
+
+
+def _make_api():
+    return Obsidian(api_key="test-key", protocol="http", host="localhost", port=27123)
+
+
+def _ok_response(status=200, text="# content"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.raise_for_status.return_value = None
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _file_exists
+# ---------------------------------------------------------------------------
+
+def test_file_exists_returns_true_on_200():
+    api = _make_api()
+    with patch("mcp_obsidian.obsidian.requests.get", return_value=_ok_response(200)):
+        assert api._file_exists("notes/a.md") is True
+
+
+def test_file_exists_returns_false_on_404():
+    api = _make_api()
+    with patch("mcp_obsidian.obsidian.requests.get", return_value=_ok_response(404)):
+        assert api._file_exists("notes/missing.md") is False
+
+
+def test_file_exists_returns_false_on_request_exception():
+    api = _make_api()
+    with patch("mcp_obsidian.obsidian.requests.get", side_effect=requests.exceptions.ConnectionError()):
+        assert api._file_exists("notes/a.md") is False
+
+
+# ---------------------------------------------------------------------------
+# rename_file — guard conditions
+# ---------------------------------------------------------------------------
+
+def test_rename_file_raises_on_same_path():
+    api = _make_api()
+    with pytest.raises(Exception, match="identical"):
+        api.rename_file("notes/a.md", "notes/a.md")
+
+
+def test_rename_file_raises_when_destination_exists():
+    api = _make_api()
+    with patch.object(api, "_file_exists", return_value=True):
+        with pytest.raises(Exception, match="already exists"):
+            api.rename_file("notes/a.md", "notes/b.md")
+
+
+# ---------------------------------------------------------------------------
+# rename_file — happy path
+# ---------------------------------------------------------------------------
+
+def test_rename_file_happy_path_calls_get_put_delete_in_order():
+    api = _make_api()
+    calls = []
+
+    with patch.object(api, "_file_exists", return_value=False), \
+         patch.object(api, "get_file_contents", side_effect=lambda p: calls.append(("get", p)) or "# body"), \
+         patch.object(api, "put_content", side_effect=lambda p, c: calls.append(("put", p, c))), \
+         patch.object(api, "delete_file", side_effect=lambda p: calls.append(("delete", p))):
+        api.rename_file("notes/a.md", "notes/b.md")
+
+    assert calls == [
+        ("get", "notes/a.md"),
+        ("put", "notes/b.md", "# body"),
+        ("delete", "notes/a.md"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# rename_file — partial failure / rollback
+# ---------------------------------------------------------------------------
+
+def test_rename_file_rolls_back_if_delete_fails():
+    api = _make_api()
+    deleted = []
+
+    def fake_delete(path):
+        if path == "notes/a.md":
+            raise Exception("delete failed")
+        deleted.append(path)
+
+    with patch.object(api, "_file_exists", return_value=False), \
+         patch.object(api, "get_file_contents", return_value="# body"), \
+         patch.object(api, "put_content"), \
+         patch.object(api, "delete_file", side_effect=fake_delete):
+        with pytest.raises(Exception, match="Rename failed"):
+            api.rename_file("notes/a.md", "notes/b.md")
+
+    assert "notes/b.md" in deleted, "compensating delete of destination must be attempted"
+
+
+def test_rename_file_re_raises_even_if_compensating_delete_also_fails():
+    api = _make_api()
+
+    with patch.object(api, "_file_exists", return_value=False), \
+         patch.object(api, "get_file_contents", return_value="# body"), \
+         patch.object(api, "put_content"), \
+         patch.object(api, "delete_file", side_effect=Exception("always fails")):
+        with pytest.raises(Exception, match="Rename failed"):
+            api.rename_file("notes/a.md", "notes/b.md")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -239,3 +239,81 @@ def test_recent_changes_handler_uses_defaults():
     handler = tools.RecentChangesToolHandler()
     _, api = _run_handler(handler, "get_recent_changes", {}, [])
     api.get_recent_changes.assert_called_once_with(10, 90)
+
+
+# ---------------------------------------------------------------------------
+# _validate_vault_path — security
+# ---------------------------------------------------------------------------
+
+def test_validate_vault_path_accepts_simple_path():
+    assert tools._validate_vault_path("notes/a.md") == "notes/a.md"
+
+
+def test_validate_vault_path_strips_leading_slash():
+    assert tools._validate_vault_path("/notes/a.md") == "notes/a.md"
+
+
+def test_validate_vault_path_rejects_dotdot_segment():
+    with pytest.raises(RuntimeError, match=r"\.\."):
+        tools._validate_vault_path("../secret.md")
+
+
+def test_validate_vault_path_rejects_dotdot_in_middle():
+    with pytest.raises(RuntimeError, match=r"\.\."):
+        tools._validate_vault_path("notes/../../etc/passwd")
+
+
+def test_validate_vault_path_rejects_backslash_traversal():
+    with pytest.raises(RuntimeError, match=r"\.\."):
+        tools._validate_vault_path("notes\\..\\secret.md")
+
+
+# ---------------------------------------------------------------------------
+# RenameFileToolHandler
+# ---------------------------------------------------------------------------
+
+def test_rename_file_handler_missing_args_raises():
+    handler = tools.RenameFileToolHandler()
+    with pytest.raises(RuntimeError, match="filepath and new_filepath"):
+        handler.run_tool({})
+    with pytest.raises(RuntimeError, match="filepath and new_filepath"):
+        handler.run_tool({"filepath": "a.md"})
+    with pytest.raises(RuntimeError, match="filepath and new_filepath"):
+        handler.run_tool({"new_filepath": "b.md"})
+
+
+def test_rename_file_handler_rejects_non_md_source():
+    handler = tools.RenameFileToolHandler()
+    with pytest.raises(RuntimeError, match="Only .md"):
+        handler.run_tool({"filepath": "image.png", "new_filepath": "image2.png"})
+
+
+def test_rename_file_handler_rejects_non_md_destination():
+    handler = tools.RenameFileToolHandler()
+    with pytest.raises(RuntimeError, match="Only .md"):
+        handler.run_tool({"filepath": "a.md", "new_filepath": "b.txt"})
+
+
+def test_rename_file_handler_rejects_path_traversal_in_source():
+    handler = tools.RenameFileToolHandler()
+    with pytest.raises(RuntimeError, match=r"\.\."):
+        handler.run_tool({"filepath": "../../secret.md", "new_filepath": "b.md"})
+
+
+def test_rename_file_handler_rejects_path_traversal_in_destination():
+    handler = tools.RenameFileToolHandler()
+    with pytest.raises(RuntimeError, match=r"\.\."):
+        handler.run_tool({"filepath": "a.md", "new_filepath": "../outside.md"})
+
+
+def test_rename_file_handler_happy_path():
+    handler = tools.RenameFileToolHandler()
+    result, api = _run_handler(handler, "rename_file", {"filepath": "a.md", "new_filepath": "b.md"})
+    api.rename_file.assert_called_once_with("a.md", "b.md")
+    assert "a.md" in _text(result) and "b.md" in _text(result)
+
+
+def test_rename_file_handler_strips_leading_slash_before_calling_api():
+    handler = tools.RenameFileToolHandler()
+    _, api = _run_handler(handler, "rename_file", {"filepath": "/a.md", "new_filepath": "/sub/b.md"})
+    api.rename_file.assert_called_once_with("a.md", "sub/b.md")


### PR DESCRIPTION
## Summary

- Adds a new `obsidian_rename_file` MCP tool to rename or move markdown notes within the vault
- Path traversal protection: rejects `..` segments in both source and destination
- Restricted to `.md` files only (binary files would be corrupted via `response.text` round-trip)
- Guards against same-path rename and silent overwrite of existing destination
- Atomic compensation: if delete fails after write, rolls back the newly written file
- 20 new unit tests covering the obsidian layer and tool handler security
- CI workflow running pytest on Python 3.11 and 3.12

## Test plan

- [x] Run `pytest tests/` — all 101 tests pass
- [x] Try renaming a note via the MCP tool in Obsidian
- [x] Verify source is gone and destination has correct content
- [x] Verify error is raised when destination already exists
- [x] Verify CI passes on both Python versions