### PR TITLE
fix: pin mcp SDK to <2.0.0 to prevent AttributeError on import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --group dev
+      - name: Run tests
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ The use prompts like this:
 - Search for all files where Azure CosmosDb is mentioned and quickly explain to me the context in which it is mentioned
 - Summarize the last meeting notes and put them into a new note 'summary meeting.md'. Add an introduction so that I can send it via email.
 
+## Requirements
+
+- Python >= 3.11
+- `mcp` Python SDK `>=1.1.0,<2.0.0` (pinned in `pyproject.toml`). `mcp-obsidian` currently registers its tool handlers via the `mcp` 1.x low-level `Server` API (`@app.list_tools()` / `@app.call_tool()`), which was removed in `mcp` 2.0. Installing with an unconstrained `mcp>=2.0` will crash at import with `AttributeError: 'Server' object has no attribute 'list_tools'`.
+
 ## Configuration
 
 ### Obsidian REST API Key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP server to work with Obsidian via the remote REST plugin"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
- "mcp>=1.1.0",
+ "mcp>=1.1.0,<2.0.0",
  "python-dotenv>=1.0.1",
  "requests>=2.32.3",
 ]


### PR DESCRIPTION
## Summary

`mcp-obsidian` registers its tool handlers via the `mcp` 1.x low-level `Server` API (`@app.list_tools()` / `@app.call_tool()`). That API was removed in `mcp` 2.0. Since `pyproject.toml` declared `mcp>=1.1.0` with no upper bound, fresh installs via `uvx`/`pip` now resolve `mcp==2.0.0` and crash at import time:

```
File ".../mcp_obsidian/server.py", line 57, in <module>
    @app.list_tools()
     ^^^^^^^^^^^^^^
AttributeError: 'Server' object has no attribute 'list_tools'
```

This is the stopgap fix suggested in #156 (option 1): constrain the dependency so existing installs keep working. A full migration to the current SDK's registration API (#156's option 2) is a larger, separate change and is left out of this PR.

## Changes

- `pyproject.toml`: pin `mcp>=1.1.0,<2.0.0`.
- `README.md`: document the constraint under a new "Requirements" section, explaining why it exists so it isn't accidentally relaxed again.
- `.github/workflows/ci.yml`: run the existing `pytest` suite on push/PR across Python 3.11 and 3.12. There was no CI in this repo, so nothing would have caught this regression automatically. `tests/test_server.py` already imports `mcp_obsidian.server` at collection time, so this workflow alone is enough to catch a repeat of this exact failure mode before a release ships — happy to also add a more direct "import the package" smoke test if that's preferred.

`uv.lock` is untouched — it already had `mcp==1.1.0` locked, which satisfies the new range.

## Test plan

- [x] `pytest` (81 tests) passes locally with `mcp==1.1.0`
- [x] Verified `uvx --with "mcp<2" mcp-obsidian` completes `initialize` and `tools/list`/`tools/call` against a real Obsidian vault (this is effectively what the new constraint makes the default behavior)
- [x] New CI workflow runs the suite on Python 3.11 and 3.12

Fixes #155
Fixes #156