### PR TITLE
fix: send Markdown-Patch-Version header on PATCH (Local REST API >= 5.x)

### DIFF
--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -171,11 +171,16 @@ class Obsidian():
         # PATCH (error 40012) — its PATCH parser only accepts the plain
         # 'text/markdown' form. We still send the body as utf-8 bytes so the
         # encoding is unambiguous on the wire.
+        # NOTE: Local REST API >= 5.0.0 requires an explicit
+        # 'Markdown-Patch-Version' header (error 40084 otherwise); '1' selects
+        # the header-driven format used here. Older plugin versions ignore
+        # unknown headers, so this is backward-compatible.
         headers = self._get_headers() | {
             'Content-Type': 'text/markdown',
             'Operation': operation,
             'Target-Type': target_type,
-            'Target': urllib.parse.quote(target)
+            'Target': urllib.parse.quote(target),
+            'Markdown-Patch-Version': '1'
         }
 
         def call_fn():

--- a/tests/test_obsidian_requests.py
+++ b/tests/test_obsidian_requests.py
@@ -190,3 +190,16 @@ def test_get_batch_file_contents_includes_successes_and_errors():
     assert "# a.md\n\nalpha\n\n---\n\n" in result
     assert "# b.md\n\nError reading file: missing\n\n---\n\n" in result
     assert "# c.md\n\ngamma\n\n---\n\n" in result
+
+
+def test_patch_content_sends_markdown_patch_version_header():
+    """Local REST API >= 5.0.0 rejects PATCH without an explicit
+    Markdown-Patch-Version header (error 40084)."""
+    api = _make_obsidian()
+    with patch("mcp_obsidian.obsidian.requests.patch", return_value=_json_response({})) as mock_patch:
+        api.patch_content("f.md", "append", "heading", "A::B", "x")
+
+    headers = mock_patch.call_args.kwargs["headers"]
+    assert headers["Markdown-Patch-Version"] == "1"
+    assert headers["Operation"] == "append"
+    assert headers["Target-Type"] == "heading"


### PR DESCRIPTION
## Problem

`obsidian_patch_content` fails with **error 40084** against Obsidian Local REST API plugin 5.x (released 2026-07-24+). The plugin's PATCH parser now requires an explicit `Markdown-Patch-Version` header to disambiguate between its two patch formats, and this client doesn't send one. Details in #158.

## Fix

Declare `Markdown-Patch-Version: 1` in `_patch_content_raw` — the instruction-header format this client already sends (`Operation` / `Target-Type` / percent-encoded `Target`, raw markdown body) is the version-1 header-driven format.

Backward-compatible: pre-5.x plugin versions ignore unknown headers.

## Testing

- New unit test asserting the header is present on PATCH requests.
- Full suite: 82 passed.
- Verified manually end-to-end against Local REST API 5.0.2: heading append works again, including the 40080 auto-qualify retry path and UTF-8 content.

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)